### PR TITLE
Fix route names in account app

### DIFF
--- a/troupon/account/tests/test_routes.py
+++ b/troupon/account/tests/test_routes.py
@@ -14,11 +14,11 @@ class UserSigninTestCase(TestCase):
         self.user.save()
 
     def test_route_get_auth_signin(self):
-        response = self.client.get('/auth/signin/')
+        response = self.client.get('/account/signin/')
         self.assertEquals(response.status_code, 200)
 
     def test_route_post_auth_signin(self):
-        response = self.client.post('/auth/signin/',
+        response = self.client.post('/account/signin/',
                                     dict(email='johndoe@gmail.com',
                                          password='12345'))
         self.assertEquals(response.status_code, 302)

--- a/troupon/account/tests/test_views.py
+++ b/troupon/account/tests/test_views.py
@@ -20,14 +20,14 @@ class UserSignInViewTestCase(TestCase):
             the class name `UserSigninView`.
         """
 
-        response = resolve('/auth/signin/')
+        response = resolve('/account/signin/')
         self.assertEquals(response.func.__name__, 'UserSigninView')
 
     def test_view_post_auth_signin(self):
         """Test that user post to signin route has a session
         """
         data = {'email': 'johndoe@gmail.com', 'password': '12345'}
-        response = self.client.post('/auth/signin/', data)
+        response = self.client.post('/account/signin/', data)
         self.assertIn('deals', response.content)
 
 

--- a/troupon/troupon/urls.py
+++ b/troupon/troupon/urls.py
@@ -5,7 +5,6 @@ import deals
 from account import views
 
 urlpatterns = [
-	url(r'^auth/', include('account.urls')),
     url(r'^account/', include('account.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^deals/', include('deals.urls')),


### PR DESCRIPTION
All routes to *auth* have been renamed to *account*. Please merge this fix.