### PR TITLE
[#105570056] (fix) remove the manage.py bower install.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,6 @@ deployment:
     branch: develop
     commands:
       - git push -f git@heroku.com:troupon-staging.git $CIRCLE_SHA1:master
-      - heroku run python troupon/manage.py bower install --settings=troupon.settings --app troupon-staging
       - heroku run python troupon/manage.py collectstatic --noinput --settings=troupon.settings --app troupon-staging
       - heroku run python troupon/manage.py makemigrations --settings=troupon.settings --app troupon-staging
       - heroku run python troupon/manage.py migrate auth --noinput --settings=troupon.settings --app troupon-staging


### PR DESCRIPTION
Heroku works just fine when this command is removed because a _bower install_ command was specified in _package.json_. Heroku runs this first before building our django app.

Please merge.