### PR TITLE
#115129333 Add Checkout Functionality

### DIFF
--- a/troupon/cart/templates/cart/cart.html
+++ b/troupon/cart/templates/cart/cart.html
@@ -39,7 +39,7 @@
 
         <div class="pull-right col-sm-2">
             <h3> Total:  $ {{ cart.total | intcomma }}</h3>
-            <button class="btn-action">Proceed to checkout</button>
+            <a href="/cart/checkout/" class="btn-action">Proceed to checkout</a>
         </div>
     </div>
 </div>

--- a/troupon/cart/templates/cart/checkout.html
+++ b/troupon/cart/templates/cart/checkout.html
@@ -7,50 +7,47 @@
 
 {% block main %}
     <div class="row">
-        <div class="col-sm-12">
+        <div class="col-md-8 col-md-offset-2">
             {% if not cart.is_empty %}
-            <div>
-                <!-- banner section -->
-                <section class="row" id="banner-section">
-                    <!-- heading -->
-                    {% include "snippet_section_heading.html" with title="Your Cart Items" %}
-                </section>
-                <div class="row">
-                    <div class="col-sm-12">
-                        <table class="table table-striped table-hover table-responsive">
-                            <thead>
-                                <tr>
-                                    <th>Title</th>
-                                    <th>Quantity</th>
-                                    <th>Subtotal</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for item in cart.items %}
-                                    <tr>
-                                        <td>{{ item.product.title }}</td>
-                                        <td>{{ item.quantity }}</td>
-                                        <td>{{ item.subtotal | intcomma }}</td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+            <div class="panel panel-default">
+                <div class="panel-heading text-center">Checkout</div>
+                <div class="panel-body text-center">
+                    <p class="text-center">Thank you for Shopping on Troupon.</p>
+                    <p> Your total is <strong>$ {{ cart.total | intcomma }}</strong></p>
+                    <div class="text-center">
+                        <form action="{% url 'process_payment' %}" method="POST" class="form-checkout">
+                        {% csrf_token %}
+                            <script
+                                src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+                                data-key="{{ payment_details.key }}"
+                                data-image="{% static 'img/logo-v-lg.png' %}"
+                                data-name="Troupon"
+                                data-description="{{ payment_details.description }}"
+                                data-amount="{{ payment_details.amount }}"
+                                data-locale="auto">
+                            </script>
+                        </form>
                     </div>
+                    <div class="divider divider-1"></div>
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="col-md-3">
+                                <i class="fa fa-cc-stripe fa-2x"></i>
+                            </div>
+                            <div class="col-md-3">
+                                <i class="fa fa-cc-paypal fa-2x"></i>
+                            </div>
+                            <div class="col-md-3">
+                                <i class="fa fa-cc-visa fa-2x"></i>
+                            </div>
+                            <div class="col-md-3">
+                                <i class="fa fa-cc-mastercard fa-2x"></i>
+                            </div>
+                        </div>    
+                    </div>
+
                 </div>
-                <h3>Total amount due: ${{ amount }}</h3>
-            </div>
-            <form action="{% url 'process_payment' %}" method="POST">
-            {% csrf_token %}
-              <script
-                src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                data-key="{{ payment_details.key }}"
-                data-image="{% static 'img/logo-v-lg.png' %}"
-                data-name="Troupon"
-                data-description="{{ payment_details.description }}"
-                data-amount="{{ payment_details.amount }}"
-                data-locale="auto">
-              </script>
-            </form>
+            </div>    
             {% else %}
                 <section class="row" id="banner-section">
                     <!-- heading -->

--- a/troupon/cart/templates/cart/checkout.html
+++ b/troupon/cart/templates/cart/checkout.html
@@ -1,13 +1,45 @@
 {% extends "base.html" %}
 {% load static %}
+{% load humanize %}
+
+{% load carton_tags %}
+{% get_cart as cart %}
 
 {% block main %}
     <div class="row">
         <div class="col-sm-12">
+            {% if not cart.is_empty %}
+            <div>
+                <!-- banner section -->
+                <section class="row" id="banner-section">
+                    <!-- heading -->
+                    {% include "snippet_section_heading.html" with title="Your Cart Items" %}
+                </section>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <table class="table table-striped table-hover table-responsive">
+                            <thead>
+                                <tr>
+                                    <th>Title</th>
+                                    <th>Quantity</th>
+                                    <th>Subtotal</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for item in cart.items %}
+                                    <tr>
+                                        <td>{{ item.product.title }}</td>
+                                        <td>{{ item.quantity }}</td>
+                                        <td>{{ item.subtotal | intcomma }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <h3>Total amount due: ${{ amount }}</h3>
+            </div>
             <form action="{% url 'process_payment' %}" method="POST">
-            <h2>{{ title }}</h2>
-            <h3>Total amount due: ${{ amount }}</h3>
-            <p>Description: {{ description }}</p>
             {% csrf_token %}
               <script
                 src="https://checkout.stripe.com/checkout.js" class="stripe-button"
@@ -19,6 +51,14 @@
                 data-locale="auto">
               </script>
             </form>
+            {% else %}
+                <section class="row" id="banner-section">
+                    <!-- heading -->
+                    {% include "snippet_section_heading.html" with title="Your Cart Is Empty." %}
+                </section>
+
+                <a href="/" id="button-continue" class="btn-action">Continue Shopping</a>
+            {% endif %}
         </div>
     </div>
 {% endblock main %}

--- a/troupon/cart/views.py
+++ b/troupon/cart/views.py
@@ -6,7 +6,6 @@ from django.template.response import TemplateResponse
 from authentication.views import LoginRequiredMixin
 from carton.cart import Cart
 from deals.models import Deal
-from django.contrib import messages
 
 
 class CheckoutView(LoginRequiredMixin, View):
@@ -23,14 +22,13 @@ class CheckoutView(LoginRequiredMixin, View):
     stripe_secret_api_key = os.getenv('STRIPE_SECRET_API_KEY')
     stripe_publishable_api_key = os.getenv('STRIPE_PUBLISHABLE_API_KEY')
 
-    def post(self, request, **kwargs):
+    def get(self, request, **kwargs):
         """Update information."""
-        # amount = request.POST.get('price', 23)
         cart = Cart(request.session)
         amount = cart.total
         amount_in_cents = int(amount) * 100
-        title = request.POST.get('title')
-        description = request.POST.get('description') or "No description"
+        title = "Total payment expected"
+        description = "Troupon shopping"
 
         # store payment details in session
         payment_details = {
@@ -68,9 +66,6 @@ class AddToCartView(LoginRequiredMixin, View):
 
         cart.add(deal, price=deal.price)
 
-        success_message = "Your item has been added to the cart."
-        messages.add_message(request, messages.INFO, success_message)
-
         return redirect('/')
 
 
@@ -80,6 +75,7 @@ class ViewCartView(LoginRequiredMixin, View):
     Returns:
         A template rendered with all the cart items.
     """
+
     def get(self, request, **kwargs):
         """Show cart items."""
         cart = Cart(request.session)

--- a/troupon/cart/views.py
+++ b/troupon/cart/views.py
@@ -1,10 +1,12 @@
-"""Import statements."""
-from django.shortcuts import render, redirect
-from django.views.generic import View
 import os
-from django.template.response import TemplateResponse
-from authentication.views import LoginRequiredMixin
+
 from carton.cart import Cart
+
+from django.shortcuts import render, redirect
+from django.template.response import TemplateResponse
+from django.views.generic import View
+
+from authentication.views import LoginRequiredMixin
 from deals.models import Deal
 
 
@@ -23,14 +25,26 @@ class CheckoutView(LoginRequiredMixin, View):
     stripe_publishable_api_key = os.getenv('STRIPE_PUBLISHABLE_API_KEY')
 
     def get(self, request, **kwargs):
-        """Update information."""
+        """
+        Create checkout page.
+
+        Gets shopping information from cart and sends it to the payment app
+        in form of a dict. It then renders the checkout template which can then
+        be used to pay.
+
+        Args:
+            request: The incoming get request object
+            **kwargs: Any keyword arguments passed to the function
+
+        Returns:
+            A template rendered with the payment details context
+        """
         cart = Cart(request.session)
         amount = cart.total
         amount_in_cents = int(amount) * 100
         title = "Total payment expected"
         description = "Troupon shopping"
 
-        # store payment details in session
         payment_details = {
             "title": title,
             "key": self.stripe_publishable_api_key,
@@ -50,14 +64,28 @@ class CheckoutView(LoginRequiredMixin, View):
 
 
 class AddToCartView(LoginRequiredMixin, View):
-    """Adds item to cart.
+    """
+    Add items to cart.
 
-    Returns:
-        A redirect to the deals homepage
+    When a logged in person clicks on Add to cart on a deal, this view
+    adds the item to the cart.
+
+    Attributes:
+        LoginRequiredMixin: Ensures the user is logged in
+        View: Normal django view
     """
 
     def post(self, request, **kwargs):
-        """Save info in cart."""
+        """
+        Add item to cart.
+
+        Args:
+            request: The incoming post request object
+            **kwargs: Any keyword arguments passed to the function
+
+        Returns:
+            A redirect to the deals homepage
+        """
         dealid = request.POST.get('dealid')
 
         deal = Deal.objects.get(id=dealid)
@@ -70,14 +98,28 @@ class AddToCartView(LoginRequiredMixin, View):
 
 
 class ViewCartView(LoginRequiredMixin, View):
-    """Allow user to view all the items in the cart.
+    """
+    Allow user to view all the items in the cart.
 
-    Returns:
-        A template rendered with all the cart items.
+    A logged in user with items in the cart can see a
+    summary of them and their prices.
+
+    Attributes:
+        LoginRequiredMixin: Ensures the user is logged in
+        View: Normal django view
     """
 
     def get(self, request, **kwargs):
-        """Show cart items."""
+        """
+        Show cart items.
+
+        Args:
+            request: The incoming get request object
+            **kwargs: Any keyword arguments passed to the function
+
+        Returns:
+            A template rendered with all the cart items.
+        """
         cart = Cart(request.session)
 
         context = {'cart': cart}
@@ -88,19 +130,29 @@ class ClearCartView(LoginRequiredMixin, View):
     """
     Clear items in cart.
 
-    Returns:
-        A redirect to the deals homepage
+    When triggered, removes every item in the cart session
+    and leaves it empty.
+
+    Attributes:
+        LoginRequiredMixin: Ensures the user is logged in
+        View: Normal django view
     """
 
     def get(self, request, **kwargs):
-        """Get cart from session and remove everything from it."""
-        # get the cart object from the session
+        """
+        Get cart from session and remove everything from it.
+
+        Args:
+            request: The incoming get request object
+            **kwargs: Any keyword arguments passed to the function
+
+        Returns:
+            A redirect to the deals homepage
+        """
         cart = Cart(request.session)
 
-        # call the cart's clear method to remove everything from it
         cart.clear()
 
-        # return a redirect to the deals homepage
         return redirect('/')
 
 
@@ -108,23 +160,29 @@ class RemoveItemView(LoginRequiredMixin, View):
     """
     Remove item from cart.
 
-    Returns:
-        A redirect to the deals homepage
+    When triggered, removes a particular item from the cart session
+    based on its id.
+
+    Attributes:
+        LoginRequiredMixin: Ensures the user is logged in
+        View: Normal django view
     """
 
     def post(self, request, **kwargs):
-        """Remove item from cart."""
-        # get the deal slug from request
+        """
+        Remove item from cart.
+
+        Args:
+            request: The incoming get request object
+            **kwargs: Any keyword arguments passed to the function
+
+        Returns:
+            A redirect to the deals homepage
+        """
         dealid = request.POST.get('dealid')
 
-        # query the deal using the unique slug
         deal = Deal.objects.get(id=dealid)
-
-        # get the cart object from the session
         cart = Cart(request.session)
-
-        # remove the queried deal object from the cart
         cart.remove(deal)
 
-        # return a redirect to the deals homepage
         return redirect('/')

--- a/troupon/payment/views.py
+++ b/troupon/payment/views.py
@@ -6,6 +6,7 @@ from django.http import HttpResponseRedirect
 from django.views.generic import View
 from django.contrib import messages
 from payment.models import TransactionHistory
+from carton.cart import Cart
 
 
 # Create your views here.
@@ -57,6 +58,10 @@ class PaymentProcessView(View):
 
                 # delete payment details from session
                 del request.session['payment_details']
+
+                # clear cart
+                cart = Cart(request.session)
+                cart.clear()
 
                 # redirect to payment status page
                 url = reverse('payment_status')

--- a/troupon/static/css/base_styles.css
+++ b/troupon/static/css/base_styles.css
@@ -1551,7 +1551,7 @@ main > section.row > [class*='col-'] {
 }
 
 .form-checkout {
-  margin-bottom: 35px;
+  padding-bottom: 35px;
 }
 
 .gallery-wrapper, .image-wrapper {

--- a/troupon/static/css/base_styles.css
+++ b/troupon/static/css/base_styles.css
@@ -1550,6 +1550,10 @@ main > section.row > [class*='col-'] {
   }
 }
 
+.form-checkout {
+  margin-bottom: 35px;
+}
+
 .gallery-wrapper, .image-wrapper {
   width: 100%;
   height: 350px;

--- a/troupon/static/scss/partials/_pages.scss
+++ b/troupon/static/scss/partials/_pages.scss
@@ -31,7 +31,7 @@ main > section.row {
 }
 
 .form-checkout {
-  margin-bottom: 35px;
+  padding-bottom: 35px;
 }
 
 .gallery-wrapper, .image-wrapper {

--- a/troupon/static/scss/partials/_pages.scss
+++ b/troupon/static/scss/partials/_pages.scss
@@ -30,6 +30,10 @@ main > section.row {
   }
 }
 
+.form-checkout {
+  margin-bottom: 35px;
+}
+
 .gallery-wrapper, .image-wrapper {
   width: 100%;
   height: 350px;


### PR DESCRIPTION
#### What does this PR do?

This PR adds functionality which allows a user to pay with Stripe for any items in his/her cart. Clicking on the checkout button on the view cart page leads to the payment page where they have the option to pay with a card. Clicking on the Pay With Card button triggers the Stripe payment gateway.

#### Description of tasks completed

* Checkout button should lead to the payment page in which the user can enter in his/her information.
* Clicking checkout without being logged in redirects to the login page before the user can proceed with shopping.
* Clicking Pay on this page goes to stripe payment.

#### How should this be manually tested?

* Add any deal to the cart by clicking its **Add to Cart** button.
* On the cart, click the **View Cart** button.
* On the next page, you can click **Proceed to Checkout** to get to the Stripe payment page.
* Click **Pay with Card** to enter your payment details.

##### What are the relevant Pivotal Tracker stories?

 #115129333

#### Screenshots

#### View cart
<img width="349" alt="screen shot 2016-03-15 at 10 44 18 am" src="https://cloud.githubusercontent.com/assets/16223682/13770865/0e4a8d5c-ea9b-11e5-8542-0fc941fd8e0b.png">

#### Cart summary
<img width="1146" alt="screen shot 2016-03-15 at 10 44 31 am" src="https://cloud.githubusercontent.com/assets/16223682/13770885/1d41a8cc-ea9b-11e5-9187-473fd65c424f.png">

#### Checkout page
<img width="753" alt="screen shot 2016-03-16 at 11 51 32 am" src="https://cloud.githubusercontent.com/assets/16223682/13806569/7b8a6aea-eb6d-11e5-9e34-2722e2b12b15.png">


#### Stripe payment 
<img width="305" alt="screen shot 2016-03-15 at 10 44 59 am" src="https://cloud.githubusercontent.com/assets/16223682/13770925/602c359e-ea9b-11e5-9db9-0d3c3b0c5a0f.png">


