### PR TITLE
#115129375 Add social media sharing capability to deals

### DIFF
--- a/troupon/deals/templates/deals/detail.html
+++ b/troupon/deals/templates/deals/detail.html
@@ -95,11 +95,21 @@
                     </div>
                     <div class="col-xs-12">
                         <ul class="social-share-links">
-                            <li><a href="" class="btn-facebook"><i class="fa fa-facebook-official fa-fw"></i></a></li>
-                            <li><a href="" class="btn-twitter"><i class="fa fa-twitter fa-fw"></i></a></li>
-                            <li><a href="" class="btn-instagram"><i class="fa fa-instagram fa-fw"></i></a></li>
-                            <li><a href="" class="btn-pinterest"><i class="fa fa-pinterest fa-fw"></i></a></li>
-                            <li><a href="" class="btn-email"><i class="fa fa-envelope fa-fw"></i></a></li>
+                            <li>
+                                <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}" class="btn-facebook">
+                                    <i class="fa fa-facebook-official fa-fw"></i>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="https://twitter.com/home?status={{ request.build_absolute_uri | urlencode }}" class="btn-twitter">
+                                    <i class="fa fa-twitter fa-fw"></i>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="https://plus.google.com/share?url={{ request.build_absolute_uri }}" class="btn-email">
+                                    <i class="fa fa-google-plus-square"></i>
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/troupon/deals/templates/deals/detail.html
+++ b/troupon/deals/templates/deals/detail.html
@@ -9,7 +9,7 @@
   <meta property="og:title" content="{{deal.title}}" />
   {% with "Check out this hot deal on Troupon" as default_description %}
     {% if deal.description %}
-    <meta property="og:description" content="{{ default_description }}" />
+    <meta property="og:description" content="{{ deal.description }}" />
     {% else %}
     <meta property="og:description" content="{{ default_description }}" />
     {% endif %}
@@ -19,12 +19,9 @@
 {% endif %}
 
 {% block main %}
-
     {% if deal %}
-
     <!-- banner section -->
     <section class="row" id="banner-section">
-
         <!-- heading -->
         {% with deal.advertiser.name|add:". "|add:deal.address as description %}
         {% include "snippet_section_heading.html" with title=deal.title  description=description %}
@@ -100,7 +97,6 @@
                         </div>
                     </div>
                 </form>
-
 
                 <!-- Sharing options -->
                 <div class="row share-options">

--- a/troupon/deals/templates/deals/detail.html
+++ b/troupon/deals/templates/deals/detail.html
@@ -4,17 +4,17 @@
 
 {% if deal %}
 {% block facebook_meta %}
-  <meta property="og:url" content="{{request.build_absolute_uri}}" />
-  <meta property="og:type" content="product" />
-  <meta property="og:title" content="{{deal.title}}" />
-  {% with "Check out this hot deal on Troupon" as default_description %}
-    {% if deal.description %}
-    <meta property="og:description" content="{{ deal.description }}" />
-    {% else %}
-    <meta property="og:description" content="{{ default_description }}" />
-    {% endif %}
-  {% endwith %}
-  <meta property="og:image" content="{{ deal.thumbnail_image_url }}" />
+    <meta property="og:url" content="{{request.build_absolute_uri}}" />
+    <meta property="og:type" content="product" />
+    <meta property="og:title" content="{{deal.title}}" />
+    {% with "Check out this hot deal on Troupon" as default_description %}
+        {% if deal.description %}
+        <meta property="og:description" content="{{ deal.description }}" />
+        {% else %}
+        <meta property="og:description" content="{{ default_description }}" />
+        {% endif %}
+    {% endwith %}
+    <meta property="og:image" content="{{ deal.thumbnail_image_url }}" />
 {% endblock facebook_meta %}
 {% endif %}
 

--- a/troupon/deals/templates/deals/detail.html
+++ b/troupon/deals/templates/deals/detail.html
@@ -2,7 +2,21 @@
 {% load static %}
 {% load humanize %}
 
-
+{% if deal %}
+{% block facebook_meta %}
+  <meta property="og:url" content="{{request.build_absolute_uri}}" />
+  <meta property="og:type" content="product" />
+  <meta property="og:title" content="{{deal.title}}" />
+  {% with "Check out this hot deal on Troupon" as default_description %}
+    {% if deal.description %}
+    <meta property="og:description" content="{{ default_description }}" />
+    {% else %}
+    <meta property="og:description" content="{{ default_description }}" />
+    {% endif %}
+  {% endwith %}
+  <meta property="og:image" content="{{ deal.thumbnail_image_url }}" />
+{% endblock facebook_meta %}
+{% endif %}
 
 {% block main %}
 
@@ -96,14 +110,16 @@
                     <div class="col-xs-12">
                         <ul class="social-share-links">
                             <li>
-                                <a href="https://www.facebook.com/sharer/sharer.php?u={{ request.build_absolute_uri }}" class="btn-facebook">
-                                    <i class="fa fa-facebook-official fa-fw"></i>
-                                </a>
+                              <a href="{{ request.build_absolute_uri }}" class="btn-facebook" id="fbshare">
+                                <i class="fa fa-facebook-official fa-fw"></i>
+                              </a>
                             </li>
                             <li>
-                                <a href="https://twitter.com/home?status={{ request.build_absolute_uri | urlencode }}" class="btn-twitter">
-                                    <i class="fa fa-twitter fa-fw"></i>
-                                </a>
+                                {% with "Checkout this hot deal on Troupon: "|add:deal.title|add:" - "|add:request.build_absolute_uri as text %}
+                                  <a href="https://twitter.com/home?status={{ text | urlencode }}" class="btn-twitter">
+                                      <i class="fa fa-twitter fa-fw"></i>
+                                  </a>
+                                {% endwith %}
                             </li>
                             <li>
                                 <a href="https://plus.google.com/share?url={{ request.build_absolute_uri }}" class="btn-email">

--- a/troupon/static/js/facebook.js
+++ b/troupon/static/js/facebook.js
@@ -11,13 +11,13 @@ window.fbAsyncInit = function() {
    var js, fjs = d.getElementsByTagName(s)[0];
    if (d.getElementById(id)) {return;}
    js = d.createElement(s); js.id = id;
-   js.src = "//connect.facebook.net/en_US/sdk.js";
+   js.src = '//connect.facebook.net/en_US/sdk.js';
    fjs.parentNode.insertBefore(js, fjs);
  }(document, 'script', 'facebook-jssdk'));
 
 // Event handler for share link
 window.onload = function() {
-  var a = document.getElementById("fbshare");
+  var a = document.getElementById('fbshare');
 
   a.onclick = function() {
     FB.ui({
@@ -26,5 +26,5 @@ window.onload = function() {
      }, function(response){});
 
      return false;
-   }
- }
+   };
+ };

--- a/troupon/static/js/facebook.js
+++ b/troupon/static/js/facebook.js
@@ -1,0 +1,30 @@
+// Facebook sharer code
+window.fbAsyncInit = function() {
+  FB.init({
+    appId      : '206165553087422',
+    xfbml      : true,
+    version    : 'v2.5'
+  });
+};
+
+(function(d, s, id){
+   var js, fjs = d.getElementsByTagName(s)[0];
+   if (d.getElementById(id)) {return;}
+   js = d.createElement(s); js.id = id;
+   js.src = "//connect.facebook.net/en_US/sdk.js";
+   fjs.parentNode.insertBefore(js, fjs);
+ }(document, 'script', 'facebook-jssdk'));
+
+// Event handler for share link
+window.onload = function() {
+  var a = document.getElementById("fbshare");
+
+  a.onclick = function() {
+    FB.ui({
+     method: 'share',
+     href: a.href,
+     }, function(response){});
+
+     return false;
+   }
+ }

--- a/troupon/templates/base.html
+++ b/troupon/templates/base.html
@@ -14,6 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="">
   <meta name="author" content="">
+  {% block facebook_meta %} {% endblock facebook_meta %}
 
   <!-- title and favicon -->
   <title>Troupon - {% block title %}Get Some!{% endblock title %}</title>
@@ -325,6 +326,8 @@
     <script src="{% static 'bower_components/datetimepicker/jquery.datetimepicker.js' %}"></script>
     <!-- Troupon base-->
     <script src="{% static 'js/app.js' %}"></script>
+    <!--Facebook SDK js code-->
+    <script src="{% static 'js/facebook.js' %}"></script>
   {% endblock base_js %}
 
   {% block extended_js %}

--- a/troupon/troupon/settings/base.py
+++ b/troupon/troupon/settings/base.py
@@ -87,6 +87,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'django.core.context_processors.request',
             ],
         },
     },


### PR DESCRIPTION
#### What does this PR do?

This PR gives customers the ability to share an individual deal on social media networks. Social media networks supported are Facebook, Twitter and Google Plus.

#### Description of task to be completed

A customer should be able to share a deal via Twitter, Facebook, Google Plus etc.

#### How should this be manually tested?

On the deals homepage, click on `More details` for any deal. In the detail view of a deal, click the corresponding button for either Twitter, Facebook or Google plus found below the deal details to share the deal.

#### What are the relevant pivotal tracker stories?

 #115129375

#### Screenshots

##### Sample sharing on Twitter
<img width="688" alt="screen shot 2016-03-29 at 10 49 44 am" src="https://cloud.githubusercontent.com/assets/16223682/14101275/0f423820-f59c-11e5-8172-730898b1035d.png">
