### PR TITLE
#118911301 Remove inactive links on user account profile page

### DIFF
--- a/troupon/account/templates/account/profile_base.html
+++ b/troupon/account/templates/account/profile_base.html
@@ -24,12 +24,6 @@
   {% url 'account_change_password' as url %}
   {% include "snippet_sidebar_item.html" with name='Change Password' url=url %}
 
-  {% url 'account_preferences' as url %}
-  {% include "snippet_sidebar_item.html" with name='Preferences' url=url %}
-
-  {% url 'account_history' as url %}
-  {% include "snippet_sidebar_item.html" with name='History' url=url %}
-
   {% if not request.user.profile.is_approved_merchant %}
     {% url 'account_merchant' as url %}
     {% include "snippet_sidebar_item.html" with name='Merchant' url=url %}


### PR DESCRIPTION
#### What does this PR do?
Removes inactive links ("Preferences" and "History") from the user account profile page.

#### Description of Task to be completed?
Remove the aforementioned links.

#### How should this be manually tested?
By going to the user account page and confirming that the links were indeed removed.

#### Any background context you want to provide?
The links will be added once the features are implemented.

#### What are the relevant pivotal tracker stories?
#118911301

#### Screenshots
<img width="1207" alt="screen shot 2016-05-11 at 10 11 35 am" src="https://cloud.githubusercontent.com/assets/18420962/15172805/db0a8d96-1760-11e6-97a7-0423f54cd654.png">
