### PR TITLE
#118910681 Remove inactive login with facebook link

### DIFF
--- a/troupon/authentication/templates/authentication/login.html
+++ b/troupon/authentication/templates/authentication/login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block extended_css %} 
+{% block extended_css %}
     <link rel="stylesheet" type="text/css" href="{% static 'css/page_styles.css' %}" />
 {% endblock extended_css %}
 
@@ -54,7 +54,6 @@
                                 </div>
                             </div>
                             <input id="loginBtn" type="submit" class="btn-action btn-form-submit" value="Log in" />
-                            <a href="">Log in with Facebook</a>
                         </form>
                     </div>
                 </div>

--- a/troupon/authentication/templates/authentication/login.html
+++ b/troupon/authentication/templates/authentication/login.html
@@ -30,7 +30,7 @@
                         <h2>Log in</h2>
                     </div>
                     <div class="col-lg-8">
-                        <p>Don't have an account yet? <a id="user_register_link" href="{% url 'register' %}" class="modal-toggle" data-modal-target="#modal-sign-up">Register Here</a></p>
+                        <p>Don't have an account yet? <a href="{% url 'register' %}" id="user_register_link">Register Here</a></p>
                     </div>
                 </header>
                 <div class="row">

--- a/troupon/authentication/templates/authentication/register.html
+++ b/troupon/authentication/templates/authentication/register.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block extended_css %} 
+{% block extended_css %}
     <link rel="stylesheet" type="text/css" href="{% static 'css/page_styles.css' %}" />
 {% endblock extended_css %}
 
@@ -61,7 +61,6 @@
                             </div>
                         </div>
                         <button type="submit" class="btn-action btn-form-submit">Register</button>
-                        <a href="">Sign up with Facebook</a>
                     </form>
                 </div>
             </div>

--- a/troupon/authentication/views.py
+++ b/troupon/authentication/views.py
@@ -181,7 +181,7 @@ class ForgotPasswordView(View):
 
         Args: request.
         Returns: A HttpResponse with a forgot_password_recovery_status template
-                 otherwise, return forgot_password template. 
+                 otherwise, return forgot_password template.
         """
         email_form = EmailForm(request.POST, auto_id=True)
         if email_form.is_valid():
@@ -245,7 +245,7 @@ class ForgotPasswordView(View):
 class ResetPasswordView(View):
     """This class allows user to reset password from recovery email.
     """
-    
+
     def get(self, request, *args, **kwargs):
         """Handles GET requests to 'account_reset_password' named route.
 
@@ -294,8 +294,8 @@ class ResetPasswordView(View):
             raise Http404("/User does not exist")
 
     def post(self, request, *args, **kwargs):
-        """Handles POST requests to 'account_reset_password' named route. 
-        
+        """Handles POST requests to 'account_reset_password' named route.
+
         Returns: A HttpResponse with the reset_password template.
         """
         reset_password_form = ResetPasswordForm(request.POST, auto_id=True)
@@ -345,19 +345,19 @@ class UserRegistrationView(View):
         """
         Handles the GET request to the 'register' named route.
         Returns: A HttpResponse with register template.
-        """ 
+        """
         args = {}
         args.update(csrf(request))
         return render(request, 'authentication/register.html', args)
 
     def post(self, request):
         """Handles POST requests to 'register' named route.
-        
+
         Raw data posted from form is received here,bound to form
         as dictionary and sent to unrendered django form for validation.
 
         Returns:
-            A HttpResponse with a register template, otherwise, redirects to the 
+            A HttpResponse with a register template, otherwise, redirects to the
             login page.
         """
         usersignupform = UserSignupForm(request.POST)
@@ -424,7 +424,7 @@ class ActivateAccountView(View):
 
     def get(self, request, *args, **kwargs):
         """Handles GET requests to 'activate_account' named route.
-        
+
         Returns: A redirect to the login page.
         Raises: A Http404 error.
         """
@@ -449,7 +449,7 @@ class UserConfirm(TemplateView):
     """
     This class handles account creation confirmation.
 
-    Attributes: 
+    Attributes:
         template_name.
     """
     template_name = 'authentication/confirm.html'
@@ -457,7 +457,7 @@ class UserConfirm(TemplateView):
     def get(self, request, *args, **kwargs):
         """
         Handles GET requests to 'confirm_registration' named route.
-        
+
         Returns:
             A rendered template response.
         """


### PR DESCRIPTION
#### What does this PR do?
 This PR introduces fixes to the following bugs:

 When a user tries logging in with incorrect account details:

- Clicking on the "Register Here" link does not display the registration form. 
- A "Log in with Facebook" link which does nothing is displayed beside the login button.

On the registration page:

-A dead register with facebook link is displayed at the bottom of the registration form. 

#### How should this be manually tested?
Try logging in with invalid account details.

#### What are the relevant pivotal tracker stories?
 #118910681

#### Screenshots
##### Link for login with facebook removed
<img width="783" alt="screen shot 2016-05-16 at 10 45 19 am" src="https://cloud.githubusercontent.com/assets/16223682/15283449/5b826688-1b53-11e6-85df-6ad60b0baa81.png">