### PR TITLE
#119267717 History and Preferences Links

### DIFF
--- a/troupon/templates/base.html
+++ b/troupon/templates/base.html
@@ -174,8 +174,7 @@
                       {% endif %}
                       <li><a href="{% url 'account_profile' %}">My Profile</a></li>
                       <li><a href="{% url 'account_change_password' %}"></i>Change Password</a></li>
-                      <li><a href="#"></i>Preferences</a></li>
-                      <li><a href="#"></i>History</a></li>
+                      <li><a href="{% url 'account_history' %}"></i>History</a></li>
                       <li  class="divider"></li>
                       <li><a href="{% url 'logout' %}">Log Out</a></li>
                     </ul>


### PR DESCRIPTION
#### What does this PR do?
This PR adds the appropriate link to the "History" item in the dropdown user menu. Additionally, the "Preferences" menu item is removed as it is unnecessary and has no corresponding page.

#### Description of Task to be completed?
- Add a link to the History page in the user menu
- Remove the Preferences menu item

#### How should this be manually tested?
Run the application. Click on the user icon in the top right corner. Test that the "History" menu item directs to the correct page. Ensure that the "Preferences" menu item is no longer there.

#### What are the relevant pivotal tracker stories?
#119267717

#### Screenshots

<img width="1221" alt="screen shot 2016-06-20 at 3 29 32 pm" src="https://cloud.githubusercontent.com/assets/18420962/16194422/3464f4ec-36fd-11e6-8fd5-6ab1724daa14.png">
