### PR TITLE
Ft consistent auth pages 121394203

### DIFF
--- a/troupon/authentication/templates/authentication/confirm.html
+++ b/troupon/authentication/templates/authentication/confirm.html
@@ -5,27 +5,32 @@
 
     <section class="row">
         <!-- heading -->
-        {% include "snippet_section_heading.html" with title="Account Registration"  description="" %}
-    </section>
-
-    <section class="row">
+        <div class="col-sm-4 hidden-xs brand-col">
+            <div class="brand">
+               <img src="{% static 'img/logo-v-lg.png' %}" alt="Troupon logo">
+            </div>
+        </div>
 
         {% if messages %}
 
             {% for message in messages %}
-                <div class="well">
+                <div class="col-sm-8">
                     <h2>Activation mail sent!</h2>
+                    <div class="well">
                     <p>You have successfully registered. A mail has been sent to your email address {{ message }}. Follow the link in the mail to activate your account</p>
                     <br >
                     <P>Troupon Team</P>
+                    </div>
                 </div>
             {% endfor %}
 
         {% else %}
 
-            <div class="well">
+            <div class="col-sm-8">
                 <h2>Account creation failed</h2>
+                <div class="well">
                 <P>Please Re-enter you signup details</P>
+            </div>
             </div>
 
         {% endif %}

--- a/troupon/authentication/templates/authentication/confirm.html
+++ b/troupon/authentication/templates/authentication/confirm.html
@@ -27,7 +27,7 @@
         {% else %}
 
             <div class="col-sm-8">
-                <h2>Account creation failed</h2>
+                <h2>Account creation failed!</h2>
                 <div class="well">
                 <P>Please Re-enter you signup details</P>
             </div>


### PR DESCRIPTION
### What Does This PR Do?
This PR changes the layout of the registration confirmation page displayed after users register on the website.

### Description Of Task To Be Completed
* Make confirmation page identical to log in and register pages

### How Should This Be Tested Manually?
Load The Troupon website and do the following:
* Navigate to the REGISTER page by clicking on **REGISTER** on the top left corner of the Homepage of the website.
* Fill all require fields and click on register.
* A confirmation page confirming registration will be displayed.

### What Are The Relevant Pivotal Tracker Stories?
#121394203

### ScreenShots

![image](https://cloud.githubusercontent.com/assets/17247426/16268411/3e5ef4b8-3886-11e6-88a0-b3f4e415af1b.png)

![image](https://cloud.githubusercontent.com/assets/17247426/16268423/4916269c-3886-11e6-8b53-1ae79493b573.png)
