### PR TITLE
Bg load modals on internal pages 121394477

### DIFF
--- a/troupon/account/templates/account/profile.html
+++ b/troupon/account/templates/account/profile.html
@@ -1,5 +1,5 @@
 {% extends "account/profile_base.html" %}
-{% load static%}
+{% load static %}
 
 {% block extended_css %}
   <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}">

--- a/troupon/account/views.py
+++ b/troupon/account/views.py
@@ -11,6 +11,8 @@ from django.contrib.auth.models import User
 from django.core.context_processors import csrf
 from django.conf import settings
 from django.utils.text import slugify
+from django.template.response import TemplateResponse
+
 
 from authentication.views import LoginRequiredMixin
 from deals.models import COUNTRY_CHOICES, KENYAN_LOCATIONS, NIGERIAN_LOCATIONS, Advertiser
@@ -60,7 +62,7 @@ class UserProfileView(LoginRequiredMixin, TemplateView):
             context_var = {}
             empty = "Form should not be submitted empty"
             messages.add_message(request, messages.INFO, empty)
-            return render(request, 'account/profile.html', context_var)
+            return TemplateResponse(request, 'account/profile.html', context_var)
 
         if form.is_valid():
             form.save()
@@ -90,7 +92,8 @@ class TransactionsView(TemplateView):
             'transactions': transactions,
         }
 
-        return render(request, 'account/transaction.html', context)
+        return TemplateResponse(request, 'account/transaction.html', context)
+
 
 class MerchantIndexView(LoginRequiredMixin, TemplateView):
     """
@@ -120,7 +123,7 @@ class MerchantIndexView(LoginRequiredMixin, TemplateView):
             ]
         }
         template_name = 'account/become_a_merchant.html'
-        return render(request, template_name, context)
+        return TemplateResponse(request, template_name, context)
 
 
 class MerchantRegisterView(LoginRequiredMixin, TemplateView):
@@ -148,7 +151,7 @@ class MerchantRegisterView(LoginRequiredMixin, TemplateView):
             messages.add_message(self.request, messages.INFO, mesg)
             return redirect(reverse('account_profile'))
 
-        return render(request, self.template_name, context)
+        return TemplateResponse(request, self.template_name, context)
 
     def post(self, request, **kwargs):
 
@@ -169,7 +172,7 @@ class MerchantRegisterView(LoginRequiredMixin, TemplateView):
             advertiser = Advertiser.objects.get(name__exact=name)
             mssg = "Company Name Already taken/exists"
             messages.add_message(request, messages.ERROR, mssg)
-            return render(request, self.template_name, context)
+            return TemplateResponse(request, self.template_name, context)
 
         except Advertiser.DoesNotExist:
 
@@ -228,7 +231,7 @@ class MerchantVerifyView(LoginRequiredMixin, TemplateView):
 
         try:
             if request.user.profile.merchant:
-                return render(request, self.template_name, context)
+                return TemplateResponse(request, self.template_name, context)
 
         except AttributeError:
             return redirect(reverse('account_profile'))
@@ -282,7 +285,7 @@ class MerchantConfirmView(LoginRequiredMixin, TemplateView):
                     application to become a merchant."""
                     messages.add_message(request, messages.INFO, mesg)
 
-                return render(request, self.template_name, context)
+                return TemplateResponse(request, self.template_name, context)
 
         except AttributeError:
             return redirect(reverse('account_profile'))
@@ -337,7 +340,7 @@ class UserChangePasswordView(LoginRequiredMixin, TemplateView):
             ]
         }
 
-        return render(request, self.template_name, context)
+        return TemplateResponse(request, self.template_name, context)
 
     def post(self, request, **kwargs):
 
@@ -356,7 +359,7 @@ class UserChangePasswordView(LoginRequiredMixin, TemplateView):
             context.update(csrf(request))
             mssg = "Your current password is incorrect"
             messages.add_message(request, messages.INFO, mssg)
-            return render(request, self.template_name, context)
+            return TemplateResponse(request, self.template_name, context)
 
         if password1 and password2:
             if password1 == password2:
@@ -368,7 +371,7 @@ class UserChangePasswordView(LoginRequiredMixin, TemplateView):
                 mssg = "Password Mismatch"
 
             messages.add_message(request, messages.INFO, mssg)
-            return render(request, self.template_name, context)
+            return TemplateResponse(request, self.template_name, context)
 
         if not password1 and not password2:
             context.update(csrf(request))
@@ -378,4 +381,4 @@ class UserChangePasswordView(LoginRequiredMixin, TemplateView):
             mssg = "Passwords should match or field should not be left empty"
 
         messages.add_message(request, messages.INFO, mssg)
-        return render(request, self.template_name, context)
+        return TemplateResponse(request, self.template_name, context)


### PR DESCRIPTION
### What Does This PR Do?
This PR makes modals for cities,merchants and categories to load on internal pages for user's profile. 

### Description Of Task To Be Completed
* On the profile pages, the cities, merchants and categories modal should contain the correct information.

### How Should This Be Tested Manually?
Go to User profile and click categories, cities and/or merchants tabs. Appropriate data should be displayed respectively

### What Are The Relevant Pivotal Tracker Stories?
#121394477

### ScreenShots
<img width="1279" alt="screen shot 2016-06-27 at 4 46 22 pm" src="https://cloud.githubusercontent.com/assets/17295618/16381935/6bfd4abe-3c87-11e6-93c3-54e0c9dec357.png">
<img width="1280" alt="screen shot 2016-06-27 at 4 52 51 pm" src="https://cloud.githubusercontent.com/assets/17295618/16382012/bf9115f2-3c87-11e6-8068-e134e82e0977.png">
<img width="1280" alt="screen shot 2016-06-27 at 4 53 25 pm" src="https://cloud.githubusercontent.com/assets/17295618/16382011/bf8f7b3e-3c87-11e6-9538-eeeb65ec31cd.png">



