### PR TITLE
[Chore #121394637] Change Layout of Deals Buttons

### DIFF
--- a/troupon/cart/tests/test_views.py
+++ b/troupon/cart/tests/test_views.py
@@ -12,7 +12,7 @@ from merchant.models import Merchant
 TEST_USER_EMAIL = 'testuser@email.com'
 TEST_USER_PASSWORD = 'testpassword'
 
-xpath_first_deal_item = "/html/body/div/div[1]/div/main/section[2]/div[2]/div/div[3]/form/button"
+xpath_first_deal_item = "//div[@class='row']/button[@class='btn-action cta-button']"
 xpath_checkout_basket = "//li[@class='dropdown'][1]/a[@class='dropdown-toggle']"
 xpath_items_quantity_text = "//li/ul/li[@class='pull-right']/h6/small/strong/span[@class='badge']"
 xpath_view_cart = "//a[@class='btn-action'][1]"

--- a/troupon/deals/tests/test_views.py
+++ b/troupon/deals/tests/test_views.py
@@ -21,9 +21,9 @@ xpath_search_results_desc = "//p[@class='description']"
 xpath_search_results_deal = "//div[@class='packery-grid deal-grid']" \
     "/div[@class='grid-item card']/form[@class='overlay row']"
 xpath_deals_page_title = "//h1[@class='title']"
-xpath_deals_first_deal = "//div[@class='grid-item card'][1]" \
-    "/form[@class='overlay row']/a[@class='moredetails btn-action']"
-xpath_more_details_button = "//a[@class='moredetails btn-action']"
+xpath_deals_first_deal = "//div[@class='grid-item card'][1]/form[@class='overlay row']"
+xpath_more_details_button = "//div[@class='grid-item card'][1]" \
+    "/form[@class='overlay row']/div[@class='row']/a[@class='more-details-btn btn-action']"
 xpath_deal_specs = "//div[@class='deals-specs']"
 
 

--- a/troupon/static/css/base_styles.css
+++ b/troupon/static/css/base_styles.css
@@ -287,6 +287,9 @@ Buttons
   .btn-form-submit {
     width: 100%;
   }
+  .more-details-btn{
+  margin-left: 90px;
+  }
 }
 
 a.btn-action, .dropdown .dropdown-menu > li > a.btn-action, .btn-action.menu-link, .btn-action.label-link, .label-link-list-v > li > a.btn-action, .label-link-list-h > li > a.btn-action, #header-bar .auth-options > li > a.btn-action, #modal-login header p > a.btn-action, #modal-register header p > a.btn-action, #modal-forgot-password header p > a.btn-action, #header-bar .nav-menu > li > a.btn-action, #header-bar .member-options > li > a.btn-action, footer .quick-links > li > a.btn-action, a.btn-action-alt, .dropdown .dropdown-menu > li > a.btn-action-alt, .btn-action-alt.menu-link, .btn-action-alt.label-link, .label-link-list-v > li > a.btn-action-alt, .label-link-list-h > li > a.btn-action-alt, #header-bar .auth-options > li > a.btn-action-alt, #modal-login header p > a.btn-action-alt, #modal-register header p > a.btn-action-alt, #modal-forgot-password header p > a.btn-action-alt, #header-bar .nav-menu > li > a.btn-action-alt, #header-bar .member-options > li > a.btn-action-alt, footer .quick-links > li > a.btn-action-alt {
@@ -481,7 +484,8 @@ Other components.
   font-size: 0.9em;
   height: 3.5em;
   min-width: 45%;
-  width: 6em;
+  width: 10em;
+  margin-left:90px;
 }
 
 .card:hover .overlay {

--- a/troupon/templates/snippet_deal_thumbnail.html
+++ b/troupon/templates/snippet_deal_thumbnail.html
@@ -4,13 +4,15 @@
   <form class="overlay row" action="/cart/add/" method="POST">
     {% csrf_token %}
     <input type="hidden" name="dealid" value="{{deal.id}}" />
-    {% if not deal.quorum %}
-      <button class="btn-action cta-button" type="submit">
-        <i class="glyphicon glyphicon-cart"></i>
-        Add to Cart
-      </button>
-    {% endif %}
-    <a href="{% url action_url deal_slug=deal.slug %}" class="moredetails btn-action">More details</a>
+    <div class="row" >
+      {% if not deal.quorum %}
+        <button class="btn-action cta-button" type="submit">
+          <i class="glyphicon glyphicon-cart"></i>
+          Add to Cart
+        </button>
+      {% endif %}
+        <a href="{% url action_url deal_slug=deal.slug %}" class="more-details-btn btn-action">More details</a>
+    </div>
   </form>
 
   <a class="item-image-wrapper" href="{% url action_url deal_slug=deal.slug %}">


### PR DESCRIPTION
#### What does this PR do?
This PR changes the layout of the "Add to Cart" and "More Details" buttons on the deals listings to a stacked layout rather than a horizontal one.

#### Description of Task to be completed?
* Modify the template rendering the deals listings so that the two buttons appear vertically stacked instead of side by side.

#### How should this be manually tested?
* Go to the Troupon site.
* Navigate to the homepage or the deals page.
* Hover over any deal. The two buttons should be stacked and not horizontally arranged.

#### What are the relevant pivotal tracker stories?
#121394637

#### Screenshots
![ss](https://cloud.githubusercontent.com/assets/18420962/16467177/d61998f8-3e4e-11e6-9e9f-902d86cee8ed.jpg)
