### PR TITLE
[Fix #119350035] Prevent deals duration filter from reloading the who…

### DIFF
--- a/troupon/static/css/base_styles.css
+++ b/troupon/static/css/base_styles.css
@@ -64,7 +64,7 @@ ul, ol {
   padding: 0;
 }
 
-.dropdown .dropdown-menu > li > a, .dropdown .dropdown-menu > li > .menu-link, .dropdown .dropdown-menu > li > .label-link, .dropdown #header-bar .auth-options.dropdown-menu > li > a, #header-bar .dropdown .auth-options.dropdown-menu > li > a, .dropdown #header-bar .nav-menu.dropdown-menu > li > a, #header-bar .dropdown .nav-menu.dropdown-menu > li > a, .dropdown #header-bar .member-options.dropdown-menu > li > a, #header-bar .dropdown .member-options.dropdown-menu > li > a, .dropdown footer .quick-links.dropdown-menu > li > a {
+.dropdown .dropdown-menu > li > a, .dropdown .dropdown-menu > li > .menu-link, .dropdown .dropdown-menu > li > .label-link, .dropdown #header-bar .auth-options.dropdown-menu > li > a, #header-bar .dropdown .auth-options.dropdown-menu > li > a, .dropdown .highlight-link .dropdown-menu > li > a, .dropdown #header-bar .nav-menu.dropdown-menu > li > a, #header-bar .dropdown .nav-menu.dropdown-menu > li > a, .dropdown #header-bar .member-options.dropdown-menu > li > a, #header-bar .dropdown .member-options.dropdown-menu > li > a, .dropdown footer .quick-links.dropdown-menu > li > a {
   padding: 5px 20px;
 }
 
@@ -167,7 +167,7 @@ h1 {
 /* ==========================================================================
 links
 ========================================================================== */
-a, .dropdown .dropdown-menu > li > a, .menu-link, .label-link, .label-link-list-v > li > a, .label-link-list-h > li > a, #header-bar .auth-options > li > a, #modal-login header p > a, #modal-register header p > a, #modal-forgot-password header p > a, .highlight-link > a, #header-bar .nav-menu > li > a, #header-bar .member-options > li > a, footer .quick-links > li > a {
+a, .dropdown .dropdown-menu > li > a, .menu-link, .label-link, .label-link-list-v > li > a, .label-link-list-h > li > a, #header-bar .auth-options > li > a, #modal-login header p > a, #modal-register header p > a, #modal-forgot-password header p > a, .highlight-link a, #header-bar .nav-menu > li > a, #header-bar .member-options > li > a, footer .quick-links > li > a {
   color: #5E5E77;
   text-decoration: none;
 }
@@ -185,22 +185,19 @@ a:focus, .dropdown .dropdown-menu > li > a:focus, .menu-link:focus, .label-link:
   color: #E67E22;
 }
 
-.menu-link, .label-link, .label-link-list-v > li > a, .dropdown .dropdown-menu.label-link-list-v > li > a, .label-link-list-v > li > .menu-link, .label-link-list-h > li > a, .dropdown .dropdown-menu.label-link-list-h > li > a, .label-link-list-h > li > .menu-link, #header-bar .auth-options > li > a, #header-bar .dropdown .dropdown-menu.auth-options > li > a, #header-bar .auth-options > li > .menu-link, #modal-login header p > a, #modal-register header p > a, #modal-forgot-password header p > a, #modal-login header p > .menu-link, #modal-register header p > .menu-link, #modal-forgot-password header p > .menu-link, .highlight-link > a, .dropdown .dropdown-menu > li.highlight-link > a, .highlight-link > .menu-link, #header-bar .nav-menu > li > a, #header-bar .dropdown .dropdown-menu.nav-menu > li > a, #header-bar .nav-menu > li > .menu-link, #header-bar .member-options > li > a, #header-bar .dropdown .dropdown-menu.member-options > li > a, #header-bar .member-options > li > .menu-link, footer .quick-links > li > a, footer .dropdown .dropdown-menu.quick-links > li > a, .dropdown footer .dropdown-menu.quick-links > li > a, footer .quick-links > li > .menu-link {
+.menu-link, .label-link, .label-link-list-v > li > a, .dropdown .dropdown-menu.label-link-list-v > li > a, .label-link-list-v > li > .menu-link, .label-link-list-h > li > a, .dropdown .dropdown-menu.label-link-list-h > li > a, .label-link-list-h > li > .menu-link, #header-bar .auth-options > li > a, #header-bar .dropdown .dropdown-menu.auth-options > li > a, #header-bar .auth-options > li > .menu-link, #modal-login header p > a, #modal-register header p > a, #modal-forgot-password header p > a, #modal-login header p > .menu-link, #modal-register header p > .menu-link, #modal-forgot-password header p > .menu-link, .highlight-link a, .highlight-link .dropdown .dropdown-menu > li > a, .dropdown .highlight-link .dropdown-menu > li > a, .highlight-link .menu-link, #header-bar .nav-menu > li > a, #header-bar .dropdown .dropdown-menu.nav-menu > li > a, #header-bar .nav-menu > li > .menu-link, #header-bar .member-options > li > a, #header-bar .dropdown .dropdown-menu.member-options > li > a, #header-bar .member-options > li > .menu-link, footer .quick-links > li > a, footer .dropdown .dropdown-menu.quick-links > li > a, .dropdown footer .dropdown-menu.quick-links > li > a, footer .quick-links > li > .menu-link {
   font-weight: 700;
 }
 
-.label-link, .label-link-list-v > li > a, .dropdown .dropdown-menu.label-link-list-v > li > a, .label-link-list-v > li > .menu-link, .label-link-list-v > li > .label-link, #header-bar .nav-menu.label-link-list-v > li > a, #header-bar .member-options.label-link-list-v > li > a, footer .quick-links.label-link-list-v > li > a, .label-link-list-h > li > a, .dropdown .dropdown-menu.label-link-list-h > li > a, .label-link-list-h > li > .menu-link, .label-link-list-h > li > .label-link, #header-bar .nav-menu.label-link-list-h > li > a, #header-bar .member-options.label-link-list-h > li > a, footer .quick-links.label-link-list-h > li > a, #header-bar .dropdown .dropdown-menu.auth-options > li > a, #header-bar .auth-options > li > .menu-link, #header-bar .auth-options > li > .label-link, #header-bar .auth-options > li > a, #header-bar footer .quick-links.auth-options > li > a, #modal-login header p > a, #modal-register header p > a, #modal-forgot-password header p > a, #modal-login header p > .menu-link, #modal-register header p > .menu-link, #modal-forgot-password header p > .menu-link, #modal-login header p > .label-link, #modal-register header p > .label-link, #modal-forgot-password header p > .label-link {
+.label-link, .label-link-list-v > li > a, .dropdown .dropdown-menu.label-link-list-v > li > a, .label-link-list-v > li > .menu-link, .label-link-list-v > li > .label-link, .highlight-link .label-link-list-v > li > a, #header-bar .nav-menu.label-link-list-v > li > a, #header-bar .member-options.label-link-list-v > li > a, footer .quick-links.label-link-list-v > li > a, .label-link-list-h > li > a, .dropdown .dropdown-menu.label-link-list-h > li > a, .label-link-list-h > li > .menu-link, .label-link-list-h > li > .label-link, .highlight-link .label-link-list-h > li > a, #header-bar .nav-menu.label-link-list-h > li > a, #header-bar .member-options.label-link-list-h > li > a, footer .quick-links.label-link-list-h > li > a, #header-bar .dropdown .dropdown-menu.auth-options > li > a, #header-bar .auth-options > li > .menu-link, #header-bar .auth-options > li > .label-link, #header-bar .highlight-link .auth-options > li > a, #header-bar .auth-options > li > a, #header-bar footer .quick-links.auth-options > li > a, #modal-login header p > a, #modal-register header p > a, #modal-forgot-password header p > a, #modal-login header p > .menu-link, #modal-register header p > .menu-link, #modal-forgot-password header p > .menu-link, #modal-login header p > .label-link, #modal-register header p > .label-link, #modal-forgot-password header p > .label-link, #modal-login header .highlight-link p > a, #modal-register header .highlight-link p > a, #modal-forgot-password header .highlight-link p > a {
   font-size: 12px;
   text-transform: uppercase;
 }
 
-
-
-.dropdown .dropdown-menu > li.highlight-link > a, .highlight-link > .menu-link, .highlight-link > .label-link, .label-link-list-v > li.highlight-link > a, .label-link-list-h > li.highlight-link > a, #header-bar .auth-options > li.highlight-link > a, #modal-login header p.highlight-link > a, #modal-register header p.highlight-link > a, #modal-forgot-password header p.highlight-link > a, .highlight-link > a, #header-bar .nav-menu > li.highlight-link > a, #header-bar .member-options > li.highlight-link > a, footer .quick-links > li.highlight-link > a {
+.highlight-link .dropdown .dropdown-menu > li > a, .dropdown .highlight-link .dropdown-menu > li > a, .highlight-link .menu-link, .highlight-link .label-link, .highlight-link .label-link-list-v > li > a, .highlight-link .label-link-list-h > li > a, .highlight-link #header-bar .auth-options > li > a, #header-bar .highlight-link .auth-options > li > a, .highlight-link #modal-login header p > a, #modal-login header .highlight-link p > a, .highlight-link #modal-register header p > a, #modal-register header .highlight-link p > a, .highlight-link #modal-forgot-password header p > a, #modal-forgot-password header .highlight-link p > a, .highlight-link a, .highlight-link #header-bar .nav-menu > li > a, #header-bar .highlight-link .nav-menu > li > a, .highlight-link #header-bar .member-options > li > a, #header-bar .highlight-link .member-options > li > a, .highlight-link footer .quick-links > li > a, footer .highlight-link .quick-links > li > a {
   color: #660066;
   font-size: 15px;
 }
-
 
 /* ==========================================================================
 Buttons
@@ -209,6 +206,7 @@ Buttons
   -webkit-appearance: none;
      -moz-appearance: none;
           appearance: none;
+  overflow: hidden;
   border: 1px solid;
   height: 55px;
   display: inline-block;
@@ -293,9 +291,6 @@ Buttons
 @media (max-width: 768px) {
   .btn-form-submit {
     width: 100%;
-  }
-  .more-details-btn{
-  margin-left: 90px;
   }
 }
 
@@ -491,8 +486,7 @@ Other components.
   font-size: 0.9em;
   height: 3.5em;
   min-width: 45%;
-  width: 10em;
-  margin-left:90px;
+  width: 6em;
 }
 
 .card:hover .overlay {
@@ -951,6 +945,13 @@ deal-detail p {
   font-size: 30px;
 }
 
+.spinner-icon {
+  position: absolute;
+  top: 22%;
+  right: 48px;
+  display: none;
+}
+
 /* ==========================================================================
 Sections
 ========================================================================== */
@@ -1155,7 +1156,7 @@ body {
   display: inline-block;
 }
 
-#header-bar .dropdown .dropdown-menu.nav-menu > li > a, #header-bar .nav-menu > li > .menu-link, #header-bar .nav-menu > li > .label-link, #header-bar .nav-menu > li > a, #header-bar footer .quick-links.nav-menu > li > a, #header-bar .dropdown .dropdown-menu.member-options > li > a, #header-bar .member-options > li > .menu-link, #header-bar .member-options > li > .label-link, #header-bar .member-options > li > a, #header-bar footer .quick-links.member-options > li > a, #header-bar .dropdown .dropdown-menu.auth-options > li > a, #header-bar .auth-options > li > .menu-link, #header-bar .auth-options > li > .label-link, #header-bar .auth-options > li > a, #header-bar footer .quick-links.auth-options > li > a {
+#header-bar .dropdown .dropdown-menu.nav-menu > li > a, #header-bar .nav-menu > li > .menu-link, #header-bar .nav-menu > li > .label-link, #header-bar .highlight-link .nav-menu > li > a, #header-bar .nav-menu > li > a, #header-bar footer .quick-links.nav-menu > li > a, #header-bar .dropdown .dropdown-menu.member-options > li > a, #header-bar .member-options > li > .menu-link, #header-bar .member-options > li > .label-link, #header-bar .highlight-link .member-options > li > a, #header-bar .member-options > li > a, #header-bar footer .quick-links.member-options > li > a, #header-bar .dropdown .dropdown-menu.auth-options > li > a, #header-bar .auth-options > li > .menu-link, #header-bar .auth-options > li > .label-link, #header-bar .auth-options > li > a, #header-bar .highlight-link .auth-options > li > a, #header-bar footer .quick-links.auth-options > li > a {
   padding: 15px;
 }
 
@@ -1179,7 +1180,7 @@ body {
   font-weight: 700;
 }
 
-#header-bar .dropdown .dropdown-menu.auth-options > li > a, #header-bar .auth-options > li > .menu-link, #header-bar .auth-options > li > .label-link, #header-bar .auth-options > li > a, #header-bar footer .quick-links.auth-options > li > a {
+#header-bar .dropdown .dropdown-menu.auth-options > li > a, #header-bar .auth-options > li > .menu-link, #header-bar .auth-options > li > .label-link, #header-bar .auth-options > li > a, #header-bar .highlight-link .auth-options > li > a, #header-bar footer .quick-links.auth-options > li > a {
   padding: 5px;
 }
 
@@ -1265,7 +1266,7 @@ footer .quick-links {
   padding: 0;
 }
 
-footer .dropdown .dropdown-menu.quick-links > li > a, .dropdown footer .dropdown-menu.quick-links > li > a, footer .quick-links > li > .menu-link, footer .quick-links > li > .label-link, footer #header-bar .auth-options.quick-links > li > a, #header-bar footer .auth-options.quick-links > li > a, footer #header-bar .nav-menu.quick-links > li > a, #header-bar footer .nav-menu.quick-links > li > a, footer #header-bar .member-options.quick-links > li > a, #header-bar footer .member-options.quick-links > li > a, footer .quick-links > li > a {
+footer .dropdown .dropdown-menu.quick-links > li > a, .dropdown footer .dropdown-menu.quick-links > li > a, footer .quick-links > li > .menu-link, footer .quick-links > li > .label-link, footer #header-bar .auth-options.quick-links > li > a, #header-bar footer .auth-options.quick-links > li > a, footer .highlight-link .quick-links > li > a, footer #header-bar .nav-menu.quick-links > li > a, #header-bar footer .nav-menu.quick-links > li > a, footer #header-bar .member-options.quick-links > li > a, #header-bar footer .member-options.quick-links > li > a, footer .quick-links > li > a {
   font-size: 12px;
 }
 
@@ -1282,7 +1283,7 @@ footer .social-links > li {
   margin: 2px;
 }
 
-footer .social-links > li > a, footer .dropdown .dropdown-menu.social-links > li > a, .dropdown footer .dropdown-menu.social-links > li > a, footer .social-links > li > .menu-link, footer .social-links > li > .label-link, footer #header-bar .auth-options.social-links > li > a, #header-bar footer .auth-options.social-links > li > a, footer #header-bar .nav-menu.social-links > li > a, #header-bar footer .nav-menu.social-links > li > a, footer #header-bar .member-options.social-links > li > a, #header-bar footer .member-options.social-links > li > a {
+footer .social-links > li > a, footer .dropdown .dropdown-menu.social-links > li > a, .dropdown footer .dropdown-menu.social-links > li > a, footer .social-links > li > .menu-link, footer .social-links > li > .label-link, footer #header-bar .auth-options.social-links > li > a, #header-bar footer .auth-options.social-links > li > a, footer .highlight-link .social-links > li > a, footer #header-bar .nav-menu.social-links > li > a, #header-bar footer .nav-menu.social-links > li > a, footer #header-bar .member-options.social-links > li > a, #header-bar footer .member-options.social-links > li > a {
   overflow: hidden;
   border: 1px solid;
   position: relative;
@@ -1300,19 +1301,19 @@ footer .social-links > li > a, footer .dropdown .dropdown-menu.social-links > li
   border-radius: 10px;
 }
 
-footer .social-links > li > a:hover, footer .dropdown .dropdown-menu.social-links > li > a:hover, footer .dropdown .dropdown-menu.social-links > li > a:active, footer .dropdown .dropdown-menu.social-links > li > a:focus, footer .social-links > li > a:active, footer .social-links > li > .menu-link:active, footer .social-links > li > .label-link:active, footer #header-bar .auth-options.social-links > li > a:active, #header-bar footer .auth-options.social-links > li > a:active, footer #header-bar .nav-menu.social-links > li > a:active, #header-bar footer .nav-menu.social-links > li > a:active, footer #header-bar .member-options.social-links > li > a:active, #header-bar footer .member-options.social-links > li > a:active, footer .social-links > li > a:focus, footer .social-links > li > .menu-link:focus, footer .social-links > li > .label-link:focus, footer #header-bar .auth-options.social-links > li > a:focus, #header-bar footer .auth-options.social-links > li > a:focus, footer #header-bar .nav-menu.social-links > li > a:focus, #header-bar footer .nav-menu.social-links > li > a:focus, footer #header-bar .member-options.social-links > li > a:focus, #header-bar footer .member-options.social-links > li > a:focus, footer .social-links > li > .menu-link:hover, footer .social-links > li > .label-link:hover, footer #header-bar .auth-options.social-links > li > a:hover, #header-bar footer .auth-options.social-links > li > a:hover, footer #header-bar .nav-menu.social-links > li > a:hover, #header-bar footer .nav-menu.social-links > li > a:hover, footer #header-bar .member-options.social-links > li > a:hover, #header-bar footer .member-options.social-links > li > a:hover {
+footer .social-links > li > a:hover, footer .dropdown .dropdown-menu.social-links > li > a:hover, footer .dropdown .dropdown-menu.social-links > li > a:active, footer .dropdown .dropdown-menu.social-links > li > a:focus, footer .social-links > li > a:active, footer .social-links > li > .menu-link:active, footer .social-links > li > .label-link:active, footer #header-bar .auth-options.social-links > li > a:active, #header-bar footer .auth-options.social-links > li > a:active, footer #header-bar .nav-menu.social-links > li > a:active, #header-bar footer .nav-menu.social-links > li > a:active, footer #header-bar .member-options.social-links > li > a:active, #header-bar footer .member-options.social-links > li > a:active, footer .social-links > li > a:focus, footer .social-links > li > .menu-link:focus, footer .social-links > li > .label-link:focus, footer #header-bar .auth-options.social-links > li > a:focus, #header-bar footer .auth-options.social-links > li > a:focus, footer #header-bar .nav-menu.social-links > li > a:focus, #header-bar footer .nav-menu.social-links > li > a:focus, footer #header-bar .member-options.social-links > li > a:focus, #header-bar footer .member-options.social-links > li > a:focus, footer .social-links > li > .menu-link:hover, footer .social-links > li > .label-link:hover, footer #header-bar .auth-options.social-links > li > a:hover, #header-bar footer .auth-options.social-links > li > a:hover, footer .highlight-link .social-links > li > a:hover, footer .highlight-link .social-links > li > a:active, footer .highlight-link .social-links > li > a:focus, footer #header-bar .nav-menu.social-links > li > a:hover, #header-bar footer .nav-menu.social-links > li > a:hover, footer #header-bar .member-options.social-links > li > a:hover, #header-bar footer .member-options.social-links > li > a:hover {
   color: #F7F7F7;
   background-color: #E67E22;
   border-color: #E67E22;
 }
 
-footer .social-links > li > a:active, footer .dropdown .dropdown-menu.social-links > li > a:active, footer .social-links > li > .menu-link:active, footer .social-links > li > .label-link:active, footer #header-bar .auth-options.social-links > li > a:active, #header-bar footer .auth-options.social-links > li > a:active, footer #header-bar .nav-menu.social-links > li > a:active, #header-bar footer .nav-menu.social-links > li > a:active, footer #header-bar .member-options.social-links > li > a:active, #header-bar footer .member-options.social-links > li > a:active {
+footer .social-links > li > a:active, footer .dropdown .dropdown-menu.social-links > li > a:active, footer .social-links > li > .menu-link:active, footer .social-links > li > .label-link:active, footer #header-bar .auth-options.social-links > li > a:active, #header-bar footer .auth-options.social-links > li > a:active, footer .highlight-link .social-links > li > a:active, footer #header-bar .nav-menu.social-links > li > a:active, #header-bar footer .nav-menu.social-links > li > a:active, footer #header-bar .member-options.social-links > li > a:active, #header-bar footer .member-options.social-links > li > a:active {
   color: #F7F7F7;
   background-color: #5E5E77;
   border-color: #5E5E77;
 }
 
-footer .social-links > li > a span, footer .dropdown .dropdown-menu.social-links > li > a span, .dropdown footer .dropdown-menu.social-links > li > a span, footer .social-links > li > .menu-link span, footer .social-links > li > .label-link span, footer #header-bar .auth-options.social-links > li > a span, #header-bar footer .auth-options.social-links > li > a span, footer #header-bar .nav-menu.social-links > li > a span, #header-bar footer .nav-menu.social-links > li > a span, footer #header-bar .member-options.social-links > li > a span, #header-bar footer .member-options.social-links > li > a span, footer .social-links > li > a i, footer .dropdown .dropdown-menu.social-links > li > a i, .dropdown footer .dropdown-menu.social-links > li > a i, footer .social-links > li > .menu-link i, footer .social-links > li > .label-link i, footer #header-bar .auth-options.social-links > li > a i, #header-bar footer .auth-options.social-links > li > a i, footer #header-bar .nav-menu.social-links > li > a i, #header-bar footer .nav-menu.social-links > li > a i, footer #header-bar .member-options.social-links > li > a i, #header-bar footer .member-options.social-links > li > a i {
+footer .social-links > li > a span, footer .dropdown .dropdown-menu.social-links > li > a span, .dropdown footer .dropdown-menu.social-links > li > a span, footer .social-links > li > .menu-link span, footer .social-links > li > .label-link span, footer #header-bar .auth-options.social-links > li > a span, #header-bar footer .auth-options.social-links > li > a span, footer .highlight-link .social-links > li > a span, footer #header-bar .nav-menu.social-links > li > a span, #header-bar footer .nav-menu.social-links > li > a span, footer #header-bar .member-options.social-links > li > a span, #header-bar footer .member-options.social-links > li > a span, footer .social-links > li > a i, footer .dropdown .dropdown-menu.social-links > li > a i, .dropdown footer .dropdown-menu.social-links > li > a i, footer .social-links > li > .menu-link i, footer .social-links > li > .label-link i, footer #header-bar .auth-options.social-links > li > a i, #header-bar footer .auth-options.social-links > li > a i, footer .highlight-link .social-links > li > a i, footer #header-bar .nav-menu.social-links > li > a i, #header-bar footer .nav-menu.social-links > li > a i, footer #header-bar .member-options.social-links > li > a i, #header-bar footer .member-options.social-links > li > a i {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -1488,7 +1489,7 @@ footer .copyright p {
           transform: translate(-50%, -50%);
 }
 
-#modal-login header p > .menu-link, #modal-register header p > .menu-link, #modal-forgot-password header p > .menu-link, #modal-login header p > .label-link, #modal-register header p > .label-link, #modal-forgot-password header p > .label-link, #modal-login header p > a, #modal-register header p > a, #modal-forgot-password header p > a {
+#modal-login header p > .menu-link, #modal-register header p > .menu-link, #modal-forgot-password header p > .menu-link, #modal-login header p > .label-link, #modal-register header p > .label-link, #modal-forgot-password header p > .label-link, #modal-login header p > a, #modal-register header p > a, #modal-forgot-password header p > a, #modal-login header .highlight-link p > a, #modal-register header .highlight-link p > a, #modal-forgot-password header .highlight-link p > a {
   margin-left: 5px;
 }
 

--- a/troupon/static/js/app.js
+++ b/troupon/static/js/app.js
@@ -183,12 +183,20 @@ $(document).ready(function() {
         var $queryString = '?dtf=' + event.currentTarget.selectedIndex +
             '&pg=1';
         var $path = $(location).attr('pathname');
-        $.ajax({url: $path + $queryString, success: 
-            function(result) {
-                $('.description').detach();
+        $.ajax({url: $path + $queryString,
+            beforeSend: function() {
+                $(".spinner-icon").show();
+            },
+            complete: function() {
+                $(".spinner-icon").hide();
+            },
+            success: function(result) {
                 $('.section-heading').nextAll().detach();
-                var $index = result.html.search('<p class="description">');
+                var $descriptionText = result.html.match(
+                    /(<p class="description">[A-z, ]+[:|!]<\/p>)/);
+                var $index = result.html.search('<!-- admin action -->');
                 var $html = result.html.slice($index, -1);
+                $("p.description").replaceWith($descriptionText[1]);
                 $($html).insertAfter('.section-heading');
                 initDealItemsLayout();
         }});

--- a/troupon/static/scss/partials/_components.scss
+++ b/troupon/static/scss/partials/_components.scss
@@ -561,3 +561,10 @@ deal-detail {
     transform: translateY(-50%);
   }
 }
+
+.spinner-icon {
+  position: absolute;
+  top: 22%;
+  right: 48px;
+  display: none;
+}

--- a/troupon/templates/snippet_section_heading.html
+++ b/troupon/templates/snippet_section_heading.html
@@ -4,7 +4,7 @@
     <div class="deal-detail col-xs-12 col-sm-8">
       <h1 class="title">{{ title|title }}</h1>
       {% if description %}
-        <p class="description">{{ description|truncatechars:150|capfirst }}<p>
+        <p class="description">{{ description|truncatechars:150|capfirst }}</p>
       {% endif %}
     </div>
     <div class="col-xs-12 col-sm-4">
@@ -22,6 +22,10 @@
               </option>
             {% endfor %}
           </select>
+          <div class="spinner-icon">
+            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
+            <span class="sr-only">Loading...</span>
+          </div>
         </div>
 
         {% else %}


### PR DESCRIPTION
…le page
…le page

#### What does this PR do?
This PR prevents the whole page from loading on a change of the deals duration filter. 

#### Description of Task to be Completed?
- Make HTTP requests asynchronous using Ajax.
- Return JSON responses to AJAX requests.
- Display an animation in date-filter select box to indicate that processing is being done.

#### How would this be manually tested?
- Go to the home page or deals page
- Change the date filter selector
- Confirm that only the description and deals items are reloaded on that page.

#### What are relevant Pivotal Tracker stories?
#119350035

#### ScreenShots
![screen shot 2016-07-19 at 11 43 17 am](https://cloud.githubusercontent.com/assets/7263503/16948158/f511aff0-4daa-11e6-805c-b808eebb384d.png)

