### PR TITLE
#121394637 Centre Deals Buttons Correctly

### DIFF
--- a/troupon/deals/tests/test_views.py
+++ b/troupon/deals/tests/test_views.py
@@ -23,7 +23,7 @@ xpath_search_results_deal = "//div[@class='packery-grid deal-grid']" \
 xpath_deals_page_title = "//h1[@class='title']"
 xpath_deals_first_deal = "//div[@class='grid-item card'][1]/form[@class='overlay row']"
 xpath_more_details_button = "//div[@class='grid-item card'][1]" \
-    "/form[@class='overlay row']/div[@class='row']/a[@class='more-details-btn btn-action']"
+    "/form[@class='overlay row']/div[@class='row']/div/a[@class='btn-action']"
 xpath_deal_specs = "//div[@class='deals-specs']"
 
 

--- a/troupon/static/css/base_styles.css
+++ b/troupon/static/css/base_styles.css
@@ -17,7 +17,7 @@ ul, ol {
 }
 
 .row {
-  margin: 0px;
+  margin: auto;
 }
 
 [class*='col-'] {
@@ -287,9 +287,6 @@ Buttons
   .btn-form-submit {
     width: 100%;
   }
-  .more-details-btn{
-  margin-left: 90px;
-  }
 }
 
 a.btn-action, .dropdown .dropdown-menu > li > a.btn-action, .btn-action.menu-link, .btn-action.label-link, .label-link-list-v > li > a.btn-action, .label-link-list-h > li > a.btn-action, #header-bar .auth-options > li > a.btn-action, #modal-login header p > a.btn-action, #modal-register header p > a.btn-action, #modal-forgot-password header p > a.btn-action, #header-bar .nav-menu > li > a.btn-action, #header-bar .member-options > li > a.btn-action, footer .quick-links > li > a.btn-action, a.btn-action-alt, .dropdown .dropdown-menu > li > a.btn-action-alt, .btn-action-alt.menu-link, .btn-action-alt.label-link, .label-link-list-v > li > a.btn-action-alt, .label-link-list-h > li > a.btn-action-alt, #header-bar .auth-options > li > a.btn-action-alt, #modal-login header p > a.btn-action-alt, #modal-register header p > a.btn-action-alt, #modal-forgot-password header p > a.btn-action-alt, #header-bar .nav-menu > li > a.btn-action-alt, #header-bar .member-options > li > a.btn-action-alt, footer .quick-links > li > a.btn-action-alt {
@@ -485,7 +482,6 @@ Other components.
   height: 3.5em;
   min-width: 45%;
   width: 10em;
-  margin-left:90px;
 }
 
 .card:hover .overlay {

--- a/troupon/templates/snippet_deal_thumbnail.html
+++ b/troupon/templates/snippet_deal_thumbnail.html
@@ -4,14 +4,18 @@
   <form class="overlay row" action="/cart/add/" method="POST">
     {% csrf_token %}
     <input type="hidden" name="dealid" value="{{deal.id}}" />
-    <div class="row" >
+    <div class="row">
       {% if not deal.quorum %}
         <button class="btn-action cta-button" type="submit">
           <i class="glyphicon glyphicon-cart"></i>
           Add to Cart
         </button>
       {% endif %}
-        <a href="{% url action_url deal_slug=deal.slug %}" class="more-details-btn btn-action">More details</a>
+      <div>
+        <a href="{% url action_url deal_slug=deal.slug %}" class="btn-action">
+          More details
+        </a>
+      </div>
     </div>
   </form>
 


### PR DESCRIPTION
#### What does this PR do?
This PR modifies the centering of the deals buttons. 

#### Description of Task to be completed?
Correctly centre the "Add to Cart" and "More Details" buttons on the deal listings.

#### How should this be manually tested?
Visit the Troupon site. Check that the "Add to Cart" and "More Details" buttons are properly centred in each deal listing.

#### Any background context you want to provide?
This PR is to correct the way the buttons were centred in a previous PR. Previously, `margin-left:90px;` was used to push the buttons towards the centre. In this PR, `margin: auto` is used to ensure all elements in the row are centred.

#### What are the relevant pivotal tracker stories?
#121394637

#### Screenshot
<img width="1207" alt="screen shot 2016-07-19 at 15 13 23" src="https://cloud.githubusercontent.com/assets/10276604/16949493/cc3ba798-4dc3-11e6-9239-141c12042c96.png">
