### PR TITLE
[Fix #119350035] Prevent deals duration filter from reloading the who…

### DIFF
--- a/troupon/static/css/base_styles.css
+++ b/troupon/static/css/base_styles.css
@@ -467,17 +467,14 @@ Other components.
 
 .card .overlay {
   -webkit-box-align: center;
-  -webkit-align-items: center;
       -ms-flex-align: center;
           align-items: center;
   background: rgba(255, 255, 255, 0.8);
   display: -webkit-box;
-  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: row;
       -ms-flex-direction: row;
           flex-direction: row;
   min-height: 100%;
@@ -950,6 +947,13 @@ deal-detail p {
   -webkit-transform: translate(-50%, -50%);
           transform: translate(-50%, -50%);
   font-size: 30px;
+}
+
+.spinner-icon {
+  position: absolute;
+  top: 22%;
+  right: 48px;
+  display: none;
 }
 
 /* ==========================================================================

--- a/troupon/static/js/app.js
+++ b/troupon/static/js/app.js
@@ -183,12 +183,20 @@ $(document).ready(function() {
         var $queryString = '?dtf=' + event.currentTarget.selectedIndex +
             '&pg=1';
         var $path = $(location).attr('pathname');
-        $.ajax({url: $path + $queryString, success: 
-            function(result) {
-                $('.description').detach();
+        $.ajax({url: $path + $queryString,
+            beforeSend: function() {
+                $(".spinner-icon").show();
+            },
+            complete: function() {
+                $(".spinner-icon").hide();
+            },
+            success: function(result) {
                 $('.section-heading').nextAll().detach();
-                var $index = result.html.search('<p class="description">');
+                var $descriptionText = result.html.match(
+                    /(<p class="description">[A-z, ]+[:|!]<\/p>)/);
+                var $index = result.html.search('<!-- admin action -->');
                 var $html = result.html.slice($index, -1);
+                $("p.description").replaceWith($descriptionText[1]);
                 $($html).insertAfter('.section-heading');
                 initDealItemsLayout();
         }});

--- a/troupon/static/scss/partials/_components.scss
+++ b/troupon/static/scss/partials/_components.scss
@@ -563,3 +563,10 @@ deal-detail {
     transform: translateY(-50%);
   }
 }
+
+.spinner-icon {
+  position: absolute;
+  top: 22%;
+  right: 48px;
+  display: none;
+}

--- a/troupon/templates/snippet_section_heading.html
+++ b/troupon/templates/snippet_section_heading.html
@@ -4,7 +4,7 @@
     <div class="deal-detail col-xs-12 col-sm-8">
       <h1 class="title">{{ title|title }}</h1>
       {% if description %}
-        <p class="description">{{ description|truncatechars:150|capfirst }}<p>
+        <p class="description">{{ description|truncatechars:150|capfirst }}</p>
       {% endif %}
     </div>
     <div class="col-xs-12 col-sm-4">
@@ -22,6 +22,10 @@
               </option>
             {% endfor %}
           </select>
+          <div class="spinner-icon">
+            <i class="fa fa-spinner fa-pulse fa-2x fa-fw"></i>
+            <span class="sr-only">Loading...</span>
+          </div>
         </div>
 
         {% else %}


### PR DESCRIPTION
…le page

#### What does this PR do?
This PR prevents the whole page from loading on a change of the deals duration filter. 

#### Description of Task to be Completed?
- Make HTTP requests asynchronous using Ajax.
- Return JSON responses to AJAX requests.
- Display an animation in date-filter select box to indicate that processing is being done.

#### How would this be manually tested?
- Go to the home page or deals page
- Change the date filter selector
- Confirm that only the description and deals items are reloaded on that page.

#### What are relevant Pivotal Tracker stories?
#119350035

#### ScreenShots
![screen shot 2016-07-19 at 11 43 17 am](https://cloud.githubusercontent.com/assets/7263503/16948158/f511aff0-4daa-11e6-805c-b808eebb384d.png)

