### PR TITLE
Ft categorize deals 126489281

### DIFF
--- a/troupon/deals/migrations/0005_auto_20160801_0951.py
+++ b/troupon/deals/migrations/0005_auto_20160801_0951.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import cloudinary.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('deals', '0004_advertiser_logo'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='deal',
+            name='type',
+            field=models.SmallIntegerField(default=1, choices=[(1, b'Physical'), (2, b'Virtual')]),
+        ),
+        migrations.AlterField(
+            model_name='advertiser',
+            name='logo',
+            field=cloudinary.models.CloudinaryField(default=b'img/logo-v-lg.png', max_length=255, blank=True),
+        ),
+    ]

--- a/troupon/deals/models.py
+++ b/troupon/deals/models.py
@@ -69,6 +69,9 @@ EPOCH_CHOICES = [
     (-1, "Show All"),
 ]
 
+# Category of deal as either physical or virtual
+DEAL_TYPES = [(1, 'Physical'), (2, 'Virtual')]
+
 
 class Deal(models.Model):
     """Deals within the troupon system are represented by this
@@ -101,6 +104,7 @@ class Deal(models.Model):
     active = models.BooleanField(default=False)
     featured = models.BooleanField(default=False)
     max_quantity_available = models.IntegerField()
+    type = models.SmallIntegerField(choices=DEAL_TYPES, default=1)
     date_created = models.DateField(auto_now_add=True)
     date_last_modified = models.DateField(auto_now=True)
     date_end = models.DateField(blank=True, null=True)
@@ -181,9 +185,11 @@ class Advertiser(ImageMixin, models.Model):
     address = models.CharField(max_length=200, default='')
     country = models.SmallIntegerField(choices=COUNTRY_CHOICES, default=2)
     if country == 1:
-        location = models.SmallIntegerField(choices=NIGERIAN_LOCATIONS, default=25)
+        location = models.SmallIntegerField(
+            choices=NIGERIAN_LOCATIONS, default=25)
     else:
-        location = models.SmallIntegerField(choices=KENYAN_LOCATIONS, default=47)
+        location = models.SmallIntegerField(
+            choices=KENYAN_LOCATIONS, default=47)
     telephone = models.CharField(max_length=60, default='')
     email = models.EmailField(default='')
     logo = CloudinaryField(
@@ -229,7 +235,7 @@ def set_deal_slug(sender, instance, **kwargs):
         slug = slugify('%s %s' % (instance.title, date_created))
 
         deal_slug_exists = Deal.objects.filter(
-                slug__startswith=slug).order_by('-date_created')
+            slug__startswith=slug).order_by('-date_created')
 
         if deal_slug_exists:
             deal_title_slug = slugify(instance.title)

--- a/troupon/merchant/templates/merchant/deal_create.html
+++ b/troupon/merchant/templates/merchant/deal_create.html
@@ -8,163 +8,173 @@
 
 {% block subview %}
 <div class="row">
-  <div class="col-sm-7">
-
-    <form method="post" id="createdealform" action="{% url 'merchant_create_deal' %}" enctype="multipart/form-data">
-
-      <div class="custom-form-group col-lg-12">
-        <label>Price</label>
-        <div class="custom-input-group">
-          <input type="number" name="price" class="form-control" id="id_price" value="" placeholder="Amount">
-        </div>
-      </div>
-
-      <div class="custom-form-group col-lg-12">
-        <label>Original Price:</label>
-        <div class="custom-input-group">
-          <input type="number" name="original_price" class="form-control" id="" value="" placeholder="12345">
-        </div>
-      </div>
-
-      <div class="custom-form-group col-lg-12">
-        <label>Country<span class="label-asterik">*</span></label>
-        <div class="custom-input-group">
-          <span class="right-icon"><i class="fa fa-angle-down"></i></span>
-          <select name="user_country" placeholder="Kenya" id="user-country">
-            <option value="0" selected>Select your country</option>
-            {% for choice in countries.choices %}
-              <option value="{{ choice.0 }}">
-                {{ choice.1 }}
-              </option>
-            {% endfor %}
-          </select>
-        </div>
-      </div>
-
-      <div class="custom-form-group col-lg-12 hidden" id="kenyan-locations">
-        <label>Location<span class="label-asterik">*</span></label>
-        <div class="custom-input-group">
-          <span class="right-icon"><i class="fa fa-angle-down"></i></span>
-          <select name="kenya_user_location" placeholder="Nairobi">
-            {% for choice in locations_kenya.choices %}
-              <option value="{{ choice.0 }}"  {% if choice.0 == locations_kenya.default %}selected{% endif %}>
-                {{ choice.1 }}
-              </option>
-            {% endfor %}
-          </select>
-        </div>
-      </div>
-
-      <div class="custom-form-group col-lg-12 hidden" id="nigerian-locations">
-        <label>Location<span class="label-asterik">*</span></label>
-        <div class="custom-input-group">
-          <span class="right-icon"><i class="fa fa-angle-down"></i></span>
-          <select name="nigeria_user_location" placeholder="Lagos">
-            <option value="0" selected>Select your location</option>.
-            {% for choice in locations_nigeria.choices %}
-              <option value="{{ choice.0 }}" {% if choice.0 == locations_nigeria.default %}selected{% endif %} >
-                {{ choice.1 }}
-              </option>
-            {% endfor %}
-          </select>
-        </div>
-      </div>
-
-      <div class="custom-form-group col-lg-12">
-        <label>Currency</label>
-        <div class="custom-input-group">
-          <span class="right-icon"><i class="fa fa-angle-down"></i></span>
-          <select name="currency" placeholder="currency" required>
-            {% for choice in currency.choices %}
-              <option value="{{ choice.0 }}" {% if choice.0 == currency.default %}selected{% endif %} >
-                {{ choice.1 }}
-              </option>
-            {% endfor %}
-          </select>
-        </div>
-      </div>
-
-      <div class="custom-form-group col-lg-12">
-          <label>Category:<span class="label-asterik">*</span></label>
-          <div class="custom-input-group">
-            <span class="right-icon"><i class="fa fa-angle-down"></i></span>
-            <select name="category" placeholder="category" required>
-              {% for choice in category %}
-                <option value="{{ choice.id }}">
-                  {{ choice }}
-                </option>
-              {% endfor %}
-            </select>
-          </div>
-        </div>
-
-        <div class="custom-form-group col-lg-12">
-          <label>Quorum </label>
-          <div class="custom-input-group">
-            <input type="number" name="quorum" id="#" value="" placeholder="quorum (Optional, ignore to make deal free for all)">
-          </div>
-        </div>
-
-        <div class="custom-form-group col-lg-12">
-          <label>Disclamer </label>
-          <div class="custom-input-group">
-            <textarea class="custom-input-group" name="disclaimer" id="#" value="" placeholder="disclaimer"></textarea>
-          </div>
-        </div>
-
-        <div class="custom-form-group col-lg-12">
-          <label>Description </label>
-          <div class="custom-input-group">
-            <textarea class="custom-input-group" name="description" id="#" value="" placeholder="description"></textarea>
-          </div>
-        </div>
-
-        <div class="custom-form-group col-lg-12">
-          <label>Title</label>
-          <div class="custom-input-group">
-            <input type="text" name="title" class="form-control" id="id_title" value="" placeholder="title">
-          </div>
-        </div>
-
-        <div class="custom-form-group col-lg-12">
-          <label>Address </label>
-          <div class="custom-input-group">
-            <input type="text" name="address" class="form-control" id="" value="" placeholder="Address">
-          </div>
-        </div>
-
-
-        <div class="custom-form-group col-lg-12">
-            <label>Max Quantity Available</label>
+   <form method="post" id="createdealform" action="{% url 'merchant_create_deal' %}" enctype="multipart/form-data">
+      <div class="col-sm-6">
+          <div class="custom-form-group col-lg-12">
+            <label>Price</label>
             <div class="custom-input-group">
-              <input type="number" name="max_quantity_available" class="form-control" id="id_qty" value="" placeholder="Max quantity available">
+              <input type="number" name="price" class="form-control" id="id_price" value="" placeholder="Amount">
             </div>
           </div>
 
-        <div class="custom-form-group col-lg-12">
-          <label>Date End</label>
-          <div class="custom-input-group">
-            <input id="datetimepicker" type="text" name="date_end" class="form-control" placeholder="2001-12-31">
+          <div class="custom-form-group col-lg-12">
+            <label>Original Price:</label>
+            <div class="custom-input-group">
+              <input type="number" name="original_price" class="form-control" id="" value="" placeholder="12345">
+            </div>
           </div>
-        </div>
 
-        <div class="custom-form-group col-lg-12">
-          Set deal as : <input type="checkbox" name="active" id="" value="False"> Active
-        </div>
+          <div class="custom-form-group col-lg-12">
+            <label>Country<span class="label-asterik">*</span></label>
+            <div class="custom-input-group">
+              <span class="right-icon"><i class="fa fa-angle-down"></i></span>
+              <select name="user_country" placeholder="Kenya" id="user-country">
+                <option value="0" selected>Select your country</option>
+                {% for choice in countries.choices %}
+                  <option value="{{ choice.0 }}">
+                    {{ choice.1 }}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
 
-        <div class="custom-form-group col-lg-12">
-            {% csrf_token %}
-            <span class="btn btn-default btn-file">Choose File
-              <input name="image" type="file" size="#" required>
-            </span>
-        </div>
+          <div class="custom-form-group col-lg-12 hidden" id="kenyan-locations">
+            <label>Location<span class="label-asterik">*</span></label>
+            <div class="custom-input-group">
+              <span class="right-icon"><i class="fa fa-angle-down"></i></span>
+              <select name="kenya_user_location" placeholder="Nairobi">
+                {% for choice in locations_kenya.choices %}
+                  <option value="{{ choice.0 }}"  {% if choice.0 == locations_kenya.default %}selected{% endif %}>
+                    {{ choice.1 }}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+
+          <div class="custom-form-group col-lg-12 hidden" id="nigerian-locations">
+            <label>Location<span class="label-asterik">*</span></label>
+            <div class="custom-input-group">
+              <span class="right-icon"><i class="fa fa-angle-down"></i></span>
+              <select name="nigeria_user_location" placeholder="Lagos">
+                <option value="0" selected>Select your location</option>.
+                {% for choice in locations_nigeria.choices %}
+                  <option value="{{ choice.0 }}" {% if choice.0 == locations_nigeria.default %}selected{% endif %} >
+                    {{ choice.1 }}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+
+          <div class="custom-form-group col-lg-12">
+            <label>Currency</label>
+            <div class="custom-input-group">
+              <span class="right-icon"><i class="fa fa-angle-down"></i></span>
+              <select name="currency" placeholder="currency" required>
+                {% for choice in currency.choices %}
+                  <option value="{{ choice.0 }}" {% if choice.0 == currency.default %}selected{% endif %} >
+                    {{ choice.1 }}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+
+          <div class="custom-form-group col-lg-12">
+              <label>Category:<span class="label-asterik">*</span></label>
+              <div class="custom-input-group">
+                <span class="right-icon"><i class="fa fa-angle-down"></i></span>
+                <select name="category" placeholder="category" required>
+                  {% for choice in category %}
+                    <option value="{{ choice.id }}">
+                      {{ choice }}
+                    </option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
+
+            <div class="custom-form-group col-lg-12">
+              <label>Quorum </label>
+              <div class="custom-input-group">
+                <input type="number" name="quorum" id="#" value="" placeholder="quorum (Optional, ignore to make deal free for all)">
+              </div>
+            </div>
+
+            <div class="custom-form-group col-lg-12">
+              <label>Disclamer </label>
+              <div class="custom-input-group">
+                <textarea class="custom-input-group" name="disclaimer" id="#" value="" placeholder="disclaimer"></textarea>
+              </div>
+            </div>
+      </div>
+      <div class="col-sm-6">
+            <div class="custom-form-group col-lg-12">
+            <label>Description </label>
+            <div class="custom-input-group">
+              <textarea class="custom-input-group" name="description" id="#" value="" placeholder="description"></textarea>
+            </div>
+            </div>
+
+            <div class="custom-form-group col-lg-12">
+              <label>Title</label>
+              <div class="custom-input-group">
+                <input type="text" name="title" class="form-control" id="id_title" value="" placeholder="title">
+              </div>
+            </div>
+
+            <div class="custom-form-group col-lg-12">
+              <label>Address </label>
+              <div class="custom-input-group">
+                <input type="text" name="address" class="form-control" id="" value="" placeholder="Address">
+              </div>
+            </div>
 
 
-      <div class="custom-form-group btn-lg col-lg-12">
-        <input id="save" type = "submit", value = "Create Deal" align="left" class="btn-action"/>
+            <div class="custom-form-group col-lg-12">
+                <label>Max Quantity Available</label>
+                <div class="custom-input-group">
+                  <input type="number" name="max_quantity_available" class="form-control" id="id_qty" value="" placeholder="Max quantity available">
+                </div>
+              </div>
+
+            <div class="custom-form-group col-lg-12">
+              <label>Date End</label>
+              <div class="custom-input-group">
+                <input id="datetimepicker" type="text" name="date_end" class="form-control" placeholder="2001-12-31">
+              </div>
+            </div>
+            <div class="custom-form-group col-lg-12">
+              <label>Deal type</label>
+              <div class="custom-input-group">
+                <span class="right-icon"><i class="fa fa-angle-down"></i></span>
+                <select name="deal_type" placeholder="Type" required>
+                {% for type in deal_types.choices %}
+                  <option value="{{ type.0 }}" {% if type.0 == type.default %}selected{% endif %} >
+                    {{ type.1 }}
+                  </option>
+                {% endfor %}
+                </select>
+              </div>
+            </div>
+            <div class="custom-form-group col-lg-12">
+              Set deal as : <input type="checkbox" name="active" id="" value="False"> Active
+            </div>
+
+            <div class="custom-form-group col-lg-12">
+                {% csrf_token %}
+                <span class="btn btn-default btn-file">Choose File
+                  <input name="image" type="file" size="#" required>
+                </span>
+            </div>
+      </div>
+       <div class="custom-form-group btn-lg col-sm-12">
+            <input id="save" type = "submit", value = "Create Deal" align="center" class="btn-action"/>
       </div>
     </form>
 
-  </div>
+  
 </div>
 {% endblock %}

--- a/troupon/merchant/views.py
+++ b/troupon/merchant/views.py
@@ -1,23 +1,24 @@
 from datetime import date, timedelta
 
-from django.shortcuts import render, get_object_or_404, redirect
+from django.contrib import messages
 from django.core.urlresolvers import reverse
+from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import View
 from django.views.generic.base import TemplateView
-from django.contrib import messages
 
-from deals.models import Deal, Category, Advertiser, \
-    COUNTRY_CHOICES, ALL_LOCATIONS, NIGERIAN_LOCATIONS, KENYAN_LOCATIONS, CURRENCY_CHOICES
 from deals.baseviews import DealListBaseView
+from deals.models import Advertiser, ALL_LOCATIONS, Category, COUNTRY_CHOICES, CURRENCY_CHOICES,\
+    Deal, DEAL_TYPES, KENYAN_LOCATIONS, NIGERIAN_LOCATIONS
 from merchant.forms import DealForm
 from merchant.mixins import MerchantMixin
 from merchant.models import Merchant
-from payment.models import TransactionHistory, Purchases
+from payment.models import Purchases, TransactionHistory
 
 
 class ManageDealsView(MerchantMixin, DealListBaseView):
 
     """Manage deals"""
+
     def get(self, request):
         """Renders a listing page for all deals that was created by a merchant
         """
@@ -46,6 +47,7 @@ class ManageDealsView(MerchantMixin, DealListBaseView):
 
 class ManageDealView(MerchantMixin, View):
     """Manage a single deal"""
+
     def get(self, request, deal_slug):
         """Renders a page showing a deal that was created by a merchant
         """
@@ -94,6 +96,7 @@ class ManageDealView(MerchantMixin, View):
 
 class TransactionsView(MerchantMixin, View):
     """View transactions for a merchant"""
+
     def get(self, request):
         """Renders a page with a table showing a deal, its buyer,
         quantity bought, time of purchase, and its price
@@ -112,6 +115,7 @@ class TransactionsView(MerchantMixin, View):
 
 class TransactionView(MerchantMixin, View):
     """View transactions detail for a merchant"""
+
     def get(self, request, transaction_id):
         """Renders a detailed view about a transaction """
         context_data = []
@@ -129,7 +133,8 @@ class CreateDealView(MerchantMixin, TemplateView):
             'locations_kenya': {'choices': KENYAN_LOCATIONS, 'default': 84},
             'locations_nigeria': {'choices': NIGERIAN_LOCATIONS, 'default': 25},
             'currency': {'choices': CURRENCY_CHOICES, 'default': 1},
-            'category': Category.objects.order_by('name')
+            'category': Category.objects.order_by('name'),
+            'deal_types': {'choices': DEAL_TYPES, 'default': 1}
         })
         return context_var
 
@@ -139,7 +144,7 @@ class CreateDealView(MerchantMixin, TemplateView):
         original_price = request.POST.get('original_price')
         currency = request.POST.get('currency')
         country = int(request.POST.get('user_country'))
-
+        deal_type = request.POST.get('deal_type')
         if country == 1:
             location = int(request.POST.get('nigeria_user_location'))
         elif country == 2:
@@ -182,17 +187,17 @@ class CreateDealView(MerchantMixin, TemplateView):
             quorum=quorum, disclaimer=disclaimer, description=description,
             address=address, max_quantity_available=max_quantity_available,
             date_end=date_end, active=active, image=image, title=title,
-            advertiser=advertiser, duration=duration
+            advertiser=advertiser, duration=duration, type=deal_type
         )
 
         deal.save()
-
         mssg = "Deal successfully created."
         messages.add_message(request, messages.ERROR, mssg)
         return redirect(reverse('merchant_manage_deals'))
 
 
 class MerchantView(MerchantMixin, View):
+
     def get(self, request, merchant_slug):
         """Renders a view containing information about a merchant"""
         pass


### PR DESCRIPTION
### What Does This PR Do?
This PR enables merchants to categorize deals as either physical or virtual. Physical deals require some form of shipping while for virtual deals communication is done via the platform.

### Description Of Task To Be Completed
Add field for categorizing a deal as either physical or virtual. 

### How Should This Be Tested Manually?
Go to Merchant Dashboard and choose **Create Deal**. Select the Deal type as either Physical or virtual.

### What Are The Relevant Pivotal Tracker Stories?
#126489281

### ScreenShots
<img width="1280" alt="screen shot 2016-08-01 at 10 46 10 am" src="https://cloud.githubusercontent.com/assets/17295618/17287387/012a8be0-57d8-11e6-8e6b-c91b72ad6054.png">
