### PR TITLE
[Feature #127640349] Paginate user transaction table

### DIFF
--- a/troupon/accounts/templates/account/transaction.html
+++ b/troupon/accounts/templates/account/transaction.html
@@ -38,6 +38,11 @@
             </table>
         </div>
     </div>
+
+    <!-- pagination -->
+    <div class="col-xs-12">
+      {% include "snippet_pagination.html" with page=transactions pagination_base_url=pagination_base_url %}
+    </div>
     {% else %}
         <h3>You have no transactions</h3>
     {% endif %}


### PR DESCRIPTION
#### What does this PR do?

This PR paginates user transaction history so there are never more than 30 items on a page.

#### Description of Task to be completed?

This task consists of:
- Adding pagination to the Transactions view.
- Updating the template to display pagination links.
- Writing tests to verify view and route work as expected. 

#### How should this be manually tested?

- Visit the Troupon site.
- First, ensure you have more than 25 transactions on the site.
- Go to your profile page. You must have an account and be logged in to perform this step.
- On your profile page, click on the History link located on the navigation pane on the left.
- Scroll to the bottom and verify the presence of pagination links.

#### What are the relevant pivotal tracker stories?

#127640349

#### Screenshots:

![image](https://cloud.githubusercontent.com/assets/7263503/17936589/2ddcb996-6a17-11e6-8067-e7e75314e8a8.png)

![image](https://cloud.githubusercontent.com/assets/7263503/17936684/819050f2-6a17-11e6-8c03-3b82bc04ac56.png)


